### PR TITLE
Set PATH so that Ipopt binary works on Windows.

### DIFF
--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module Ipopt
 using Compat
+import Compat.Libdl
 using Compat.LinearAlgebra
 
 if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
@@ -23,11 +24,17 @@ function __init__()
     # Sets up the library paths so that we can run the ipopt binary from Julia.
     # TODO: Restructure into a function that wraps the call to the binary and
     # doesn't leave environment variables changed.
-    julia_libdir = joinpath(dirname(first(filter(x -> contains(x, "libjulia"), Sys.Libdl.dllist()))), "julia")
+    julia_libdir = joinpath(dirname(first(filter(x -> contains(x, "libjulia"), Libdl.dllist()))), "julia")
+    julia_bindir = Compat.Sys.BINDIR
+    pathsep = Compat.Sys.iswindows() ? ';' : ':'
     @static if Compat.Sys.isapple()
-        ENV["DYLD_LIBRARY_PATH"] = string(get(ENV, "DYLD_LIBRARY_PATH", ""), ":", julia_libdir)
+        ENV["DYLD_LIBRARY_PATH"] = string(get(ENV, "DYLD_LIBRARY_PATH", ""),
+                                          pathsep, julia_libdir)
     elseif Compat.Sys.islinux()
-        ENV["LD_LIBRARY_PATH"] = string(get(ENV, "LD_LIBRARY_PATH", ""), ":", julia_libdir)
+        ENV["LD_LIBRARY_PATH"] = string(get(ENV, "LD_LIBRARY_PATH", ""),
+                                        pathsep, julia_libdir)
+    elseif Compat.Sys.iswindows()
+        ENV["PATH"] = string(ENV["PATH"], pathsep, julia_bindir)
     end
 end
 

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -26,15 +26,14 @@ function __init__()
     # doesn't leave environment variables changed.
     julia_libdir = joinpath(dirname(first(filter(x -> contains(x, "libjulia"), Libdl.dllist()))), "julia")
     julia_bindir = Compat.Sys.BINDIR
-    pathsep = Compat.Sys.iswindows() ? ';' : ':'
     @static if Compat.Sys.isapple()
         ENV["DYLD_LIBRARY_PATH"] = string(get(ENV, "DYLD_LIBRARY_PATH", ""),
-                                          pathsep, julia_libdir)
+                                          ":", julia_libdir)
     elseif Compat.Sys.islinux()
-        ENV["LD_LIBRARY_PATH"] = string(get(ENV, "LD_LIBRARY_PATH", ""),
-                                        pathsep, julia_libdir)
+        ENV["LD_LIBRARY_PATH"] = string(get(ENV, "LD_LIBRARY_PATH", ""), ":",
+                                        julia_libdir)
     elseif Compat.Sys.iswindows()
-        ENV["PATH"] = string(ENV["PATH"], pathsep, julia_bindir)
+        ENV["PATH"] = string(ENV["PATH"], ";", julia_bindir)
     end
 end
 


### PR DESCRIPTION
Fixes #119 
Thanks @staticfloat!
The remaining failure on 0.7 is because https://github.com/JuliaOpt/MathOptInterface.jl/commit/48059841418f92017413b5ecf1bebc02d2026568 isn't tagged.