### PR TITLE
Use obj_scaling_factor to set objective sense

### DIFF
--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -323,23 +323,28 @@ function openOutputFile(prob::IpoptProblem, file_name::String, print_level::Int)
     end
 end
 
-# TODO: Verify this function even works! Trying it with 0.5 on HS071
-# seems to change nothing.
-function setProblemScaling(prob::IpoptProblem, obj_scaling::Float64,
-    x_scaling = nothing,
-    g_scaling = nothing)
-    #/** Optional function for setting scaling parameter for the NLP.
-    # *  This corresponds to the get_scaling_parameters method in TNLP.
-    # *  If the pointers x_scaling or g_scaling are NULL, then no scaling
-    # *  for x resp. g is done. */
-    x_scale_arg = (x_scaling == nothing) ? C_NULL : x_scaling
-    g_scale_arg = (g_scaling == nothing) ? C_NULL : g_scaling
-    ret = ccall((:SetIpoptProblemScaling, libipopt),
-    Cint, (Ptr{Cvoid}, Float64, Ptr{Float64}, Ptr{Float64}),
-    prob.ref, obj_scaling, x_scale_arg, g_scale_arg)
+#/** Optional function for setting scaling parameter for the NLP.
+# *  This corresponds to the get_scaling_parameters method in TNLP.
+# *  If the pointers x_scaling or g_scaling are NULL, then no scaling
+# *  for x resp. g is done. */
+function setProblemScaling(
+    prob::IpoptProblem,
+    obj_scaling::Float64,
+    x_scaling::Union{Nothing, Vector{Float64}} = nothing,
+    g_scaling::Union{Nothing, Vector{Float64}} = nothing,
+)
+    x_scale_arg = (x_scaling === nothing) ? C_NULL : x_scaling
+    g_scale_arg = (g_scaling === nothing) ? C_NULL : g_scaling
+    ret = ccall(
+        (:SetIpoptProblemScaling, libipopt),
+        Cint,
+        (Ptr{Cvoid}, Float64, Ptr{Float64}, Ptr{Float64}),
+        prob.ref, obj_scaling, x_scale_arg, g_scale_arg
+    )
     if ret == 0
         error("IPOPT: Error setting problem scaling.")
     end
+    return
 end
 
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -778,7 +778,7 @@ function MOI.get(
     MOI.throw_if_not_valid(model, ci)
     upper = model.variable_info[ci.value].upper_bound_dual_start
     lower = model.variable_info[ci.value].lower_bound_dual_start
-    return upper == lower ? nothing : lower + upper
+    return (upper === lower === nothing) ? nothing : lower + upper
 end
 
 macro define_constraint_dual_start(function_type, set_type, prefix)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -78,6 +78,44 @@ function test_unittest()
     )
 end
 
+function test_ConstraintDualStart()
+    model = Ipopt.Optimizer()
+    x = MOI.add_variables(model, 2)
+    l = MOI.add_constraint(model, x[1], MOI.GreaterThan(1.0))
+    u = MOI.add_constraint(model, x[1], MOI.LessThan(1.0))
+    e = MOI.add_constraint(model, x[2], MOI.EqualTo(1.0))
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
+        MOI.LessThan(1.5),
+    )
+    @test MOI.get(model, MOI.ConstraintDualStart(), l) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), u) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), e) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) === nothing
+    @test MOI.get(model, MOI.NLPBlockDualStart()) === nothing
+    MOI.set(model, MOI.ConstraintDualStart(), l, 1.0)
+    MOI.set(model, MOI.ConstraintDualStart(), u, -1.0)
+    MOI.set(model, MOI.ConstraintDualStart(), e, -1.5)
+    MOI.set(model, MOI.ConstraintDualStart(), c, 2.0)
+    MOI.set(model, MOI.NLPBlockDualStart(), [1.0, 2.0])
+    @test MOI.get(model, MOI.ConstraintDualStart(), l) == 1.0
+    @test MOI.get(model, MOI.ConstraintDualStart(), u) == -1.0
+    @test MOI.get(model, MOI.ConstraintDualStart(), e) == -1.5
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) == 2.0
+    @test MOI.get(model, MOI.NLPBlockDualStart()) == [1.0, 2.0]
+    MOI.set(model, MOI.ConstraintDualStart(), l, nothing)
+    MOI.set(model, MOI.ConstraintDualStart(), u, nothing)
+    MOI.set(model, MOI.ConstraintDualStart(), e, nothing)
+    MOI.set(model, MOI.ConstraintDualStart(), c, nothing)
+    MOI.set(model, MOI.NLPBlockDualStart(), nothing)
+    @test MOI.get(model, MOI.ConstraintDualStart(), l) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), u) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), e) === nothing
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) === nothing
+    @test MOI.get(model, MOI.NLPBlockDualStart()) === nothing
+end
+
 function test_contlinear()
     MOI.Test.contlineartest(
         BRIDGED_OPTIMIZER,


### PR DESCRIPTION
Closes #184 

Avoids having to multiply objective function/gradient by -1 if `MAX_SENSE`, and makes it so the Ipopt log now displays the correct objective value, minimizing confusion for users.