### PR TITLE
fix mistake in eval_grad_f of example/hs071.jl

### DIFF
--- a/example/hs071.jl
+++ b/example/hs071.jl
@@ -8,6 +8,12 @@ using Ipopt
 # Start at (1,5,5,1)
 # End at (1.000..., 4.743..., 3.821..., 1.379...)
 
+# Expected output
+# EXIT: Optimal Solution Found.
+# Solve_Succeeded
+# [1.0, 4.742999641620817, 3.8211499816742873, 1.3794082916613506]
+# 17.014017143814982 # <<< objective function value
+
 function eval_f(x) 
   return x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3]
 end
@@ -22,7 +28,7 @@ end
 function eval_grad_f(x, grad_f)
   # Bad: grad_f    = zeros(4)  # Allocates new array
   # OK:  grad_f[:] = zeros(4)  # Modifies 'in place'
-  grad_f[1] = x[1] * x[4] + x[4] * (x[1] + x[2] + x[3])
+  grad_f[1] = 2 * x[1] * x[4] + x[4] * (x[1] + x[2] + x[3])
   grad_f[2] = x[1] * x[4]
   grad_f[3] = x[1] * x[4] + 1
   grad_f[4] = x[1] * (x[1] + x[2] + x[3])


### PR DESCRIPTION
There was a missing factor of 2 in the gradient.

The original version results were:

```
[1.0, 4.7429996418092975, 3.8211499817883072, 1.3794082897556978]
17.014017145179157
```

With this fix, the differences start around the 10th decimal place, but it reaches a smaller objective value (this is a minimization problem):

```
[1.0, 4.742999641620817, 3.8211499816742873, 1.3794082916613506]
17.014017143814982  # <<<< *.*38* as opposed to the above *.*51*
```

The stated solution at https://coin-or.github.io/Ipopt/INTERFACES.html is:
```
x=(1.00000000,4.74299963,3.82114998,1.37940829).
```
They don't mention the value of the objective function, but it comes out at `17.014017238834267`, which is fine given that the solution is rounded to 8 digits.
