### PR TITLE
Update README with linear solver instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,53 @@
-Ipopt.jl
-========
+# Ipopt.jl
 
-**Ipopt.jl** is a [Julia](http://julialang.org/) interface to the [Ipopt](http://www.coin-or.org/Ipopt/documentation/documentation.html) nonlinear solver.
+![](https://www.coin-or.org/wordpress/wp-content/uploads/2014/08/COINOR.png)
 
+**Ipopt.jl** is a [Julia](http://julialang.org/) interface to the [COIN-OR](www.coin-or.org)
+nonlinear solver [Ipopt](http://www.coin-or.org/Ipopt/documentation/documentation.html).
+
+*Note: This wrapper is maintained by the JuMP community and is not a COIN-OR
+project.*
 [![Build Status](https://github.com/jump-dev/Ipopt.jl/workflows/CI/badge.svg?branch=master)](https://github.com/jump-dev/Ipopt.jl/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/jump-dev/Ipopt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/Ipopt.jl)
 
 ## Installation
 
-The package is registered in `METADATA.jl` and so can be installed with `Pkg.add`.
-
+Install `Ipopt.jl` using the Julia package manager:
+```julia
+import Pkg; Pkg.add("Ipopt")
 ```
-julia> import Pkg; Pkg.add("Ipopt")
-```
 
-In addition to installing the `Ipopt.jl` package, this will also download and install the Ipopt binaries.
-(You do _not_ need to install Ipopt separately.)
+In addition to installing the `Ipopt.jl` package, this will also download and
+install the Ipopt binaries. You do _not_ need to install Ipopt separately.
+
 If you require a custom build of Ipopt, see the instructions below.
 
-## Custom Installation
+For details on using a different linear solver, see the `Linear Solvers` section
+below.
 
-To install custom built Ipopt binaries set the environmental variables `JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`, and call `import Pkg; Pkg.build("Ipopt")`. For instance, if the libraries are installed in `/opt/lib` and the executable is in `/opt/bin` just call
-```julia
-ENV["JULIA_IPOPT_LIBRARY_PATH"] = "/opt/lib"
-ENV["JULIA_IPOPT_EXECUTABLE_PATH"] = "/opt/bin"
-import Pkg; Pkg.build("Ipopt")
-```
-If you do not want BinaryProvider to download the default binaries on install set  `JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`  before calling `import Pkg; Pkg.add("Ipopt")`.
-
-To switch back to the default binaries clear `JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`, and call `import Pkg; Pkg.build("Ipopt")`.
-
-JuMP and MathOptInterface
-----------------------
-
-Ipopt implements the solver-independent [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) interface,
-and so can be used within modeling software like [JuMP](https://github.com/jump-dev/JuMP.jl).
-The solver object is called `Ipopt.Optimizer`. All options listed in the [Ipopt documentation](https://coin-or.github.io/Ipopt/OPTIONS.html#OPTIONS_REF) may be passed directly. For example, you can suppress output by saying `Ipopt.Optimizer(print_level=0)`. If you wish to pass an option specifically for the restoration phase, instead of using the prefix ``resto.``, use the prefix ``resto_``. For example `Ipopt.Optimizer(resto_max_iter=0)`.
+## JuMP and MathOptInterface
 
 You can use Ipopt with JuMP as follows:
 ```julia
 using JuMP, Ipopt
-model = Model(with_optimizer(Ipopt.Optimizer, max_cpu_time=60.0))
+model = Model(Ipopt.Optimizer)
+set_optimizer_attribute(model, "max_cpu_time", 60.0)
+set_optimizer_attribute(model, "print_level", 0)
 ```
 
-C Interface Wrapper
--------------------
+Supported options are listed in the [Ipopt documentation](https://coin-or.github.io/Ipopt/OPTIONS.html#OPTIONS_REF).
 
-Full documentation for the Ipopt C wrapper is available [here](http://ipoptjl.readthedocs.org/en/latest/ipopt.html). Use of the [nonlinear MathOptInterface interface](https://github.com/jump-dev/MathOptInterface.jl) is recommended over the low-level C interface because it permits one to easily switch between solvers.
+## C Interface Wrapper
+
+Full documentation for the Ipopt C wrapper is available [here](http://ipoptjl.readthedocs.org/en/latest/ipopt.html);
+however, we strongly recommend you use Ipopt via JuMP.
 
 ## `INVALID_MODEL` error
 
-If you get a termination status `MOI.INVALID_MODEL`, it is probably because you have some undefined value
-in your model, e.g., a division by zero. Fix this by removing the division, or by imposing variable bounds
-so that you cut off the undefined region.
+If you get a termination status `MOI.INVALID_MODEL`, it is probably because you
+have some undefined value in your model, e.g., a division by zero. Fix this by
+removing the division, or by imposing variable bounds so that you cut off the
+undefined region.
 
 Instead of
 ```julia
@@ -66,3 +61,51 @@ model = Model(Ipopt.Optimizer)
 @variable(model, x >= 0.0001)
 @NLobjective(model, 1 / x)
 ```
+
+## Custom Installation
+
+**Note: it is not necessary to compile a custom version of Ipopt to use a
+different linear solver. See the Linear Solvers section below.**
+
+To install custom built Ipopt binaries set the environmental variables
+`JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`, and call
+`import Pkg; Pkg.build("Ipopt")`. For instance, if the libraries are installed
+in `/opt/lib` and the executable is in `/opt/bin` just call
+```julia
+ENV["JULIA_IPOPT_LIBRARY_PATH"] = "/opt/lib"
+ENV["JULIA_IPOPT_EXECUTABLE_PATH"] = "/opt/bin"
+import Pkg; Pkg.build("Ipopt")
+```
+
+If you do not want BinaryProvider to download the default binaries on install
+set  `JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`  before
+calling `import Pkg; Pkg.add("Ipopt")`.
+
+To switch back to the default binaries clear `JULIA_IPOPT_LIBRARY_PATH` and
+`JULIA_IPOPT_EXECUTABLE_PATH`, and call `import Pkg; Pkg.build("Ipopt")`.
+
+## Linear Solvers
+
+To improve performance, Ipopt supports a number of linear solvers. Installing
+these can be tricky.
+
+### Pardiso Project
+
+1. Download Pardiso from [https://www.pardiso-project.org](https://www.pardiso-project.org)
+2. Rename the file `libpardiso-XXXXX.YYY` to `libpardiso.YYY`, and place it
+   somewhere on your load path.
+3. Set the option `set_optimizer_attribute(model, "linear_solver", "pardiso")`
+
+### MA27
+
+1. Download HSL for IPOPT from http://www.hsl.rl.ac.uk/ipopt/
+2. Unzip the download, and run the following:
+    ```
+    ./configure --prefix=</full/path/somewhere>
+    make
+    ```
+    where `</full/path/somewhere>` is replaced as appropriate.
+3. Rename the files `/full/path/somewhere/lib/libcoinhsl.xxx` to
+    `/full/path/somewhere/lib/libhsl.xxx`, and place the library somewhere on
+    your load path.
+4. Set the option `set_optimizer_attribute(model, "linear_solver", "ma27")`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,28 @@ Currently untested. If you have instructions that work, please open an issue.
 
 #### Linux
 
-Currently untested. If you have instructions that work, please open an issue.
+1. Install Fortran compiler if necessary
+   ```
+   sudo apt install gfortran
+   ```
+2. Download HSL for IPOPT from http://www.hsl.rl.ac.uk/ipopt/
+3. Unzip the download, and run the following:
+   ```
+   ./configure --prefix=</full/path/somewhere>
+   make
+   make install
+   ```
+   where `</full/path/somewhere>` is replaced as appropriate.
+4. Rename the files `/full/path/somewhere/lib/libcoinhsl.so` to
+   `/full/path/somewhere/lib/libhsl.so`, and place the library somewhere on
+   your load path.
+   - Alternatively, start Julia with `export LD_LIBRARY_PATH=/full/path/somewhere/lib; julia`
+5. Set the option `linear_solver` to `ma27`:
+   ```julia
+   using JuMP, Ipopt
+   model = Model(Ipopt.Optimizer)
+   set_optimizer_attribute(model, "linear_solver", "ma27")
+   ```
 
 #### Mac
 
@@ -148,6 +169,7 @@ Currently untested. If you have instructions that work, please open an issue.
    ```
    ./configure --prefix=</full/path/somewhere>
    make
+   make install
    ```
    where `</full/path/somewhere>` is replaced as appropriate.
 3. Rename the files `/full/path/somewhere/lib/libcoinhsl.dylib` to

--- a/README.md
+++ b/README.md
@@ -91,12 +91,30 @@ these can be tricky.
 
 ### Pardiso Project
 
+#### Linux
+
+Currently untested. If you have instructions that work, please open an issue.
+
+#### Mac
+
 1. Download Pardiso from [https://www.pardiso-project.org](https://www.pardiso-project.org)
-2. Rename the file `libpardiso-XXXXX.YYY` to `libpardiso.YYY`, and place it
+2. Rename the file `libpardiso-XXXXX.dylib` to `libpardiso.dylib`, and place it
    somewhere on your load path.
-3. Set the option `set_optimizer_attribute(model, "linear_solver", "pardiso")`
+    - Alternatively, if the library is located at `/full/path/libpardiso.dylib`,
+      start Julia with `export LD_LOAD_PATH=/full/path; julia`
+4. Set the option `set_optimizer_attribute(model, "linear_solver", "pardiso")`
+
+#### Windows
+
+Currently untested. If you have instructions that work, please open an issue.
 
 ### MA27
+
+#### Linux
+
+Currently untested. If you have instructions that work, please open an issue.
+
+#### Mac
 
 1. Download HSL for IPOPT from http://www.hsl.rl.ac.uk/ipopt/
 2. Unzip the download, and run the following:
@@ -105,7 +123,12 @@ these can be tricky.
     make
     ```
     where `</full/path/somewhere>` is replaced as appropriate.
-3. Rename the files `/full/path/somewhere/lib/libcoinhsl.xxx` to
-    `/full/path/somewhere/lib/libhsl.xxx`, and place the library somewhere on
+3. Rename the files `/full/path/somewhere/lib/libcoinhsl.dylib` to
+    `/full/path/somewhere/lib/libhsl.dylib`, and place the library somewhere on
     your load path.
+    - Alternatively, start Julia with `export LD_LOAD_PATH=/full/path/somewhere/lib; julia`
 4. Set the option `set_optimizer_attribute(model, "linear_solver", "ma27")`
+
+#### Windows
+
+Currently untested. If you have instructions that work, please open an issue.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ nonlinear solver [Ipopt](http://www.coin-or.org/Ipopt/documentation/documentatio
 
 *Note: This wrapper is maintained by the JuMP community and is not a COIN-OR
 project.*
+
 [![Build Status](https://github.com/jump-dev/Ipopt.jl/workflows/CI/badge.svg?branch=master)](https://github.com/jump-dev/Ipopt.jl/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/jump-dev/Ipopt.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/jump-dev/Ipopt.jl)
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ To switch back to the default binaries clear `JULIA_IPOPT_LIBRARY_PATH` and
 ## Linear Solvers
 
 To improve performance, Ipopt supports a number of linear solvers. Installing
-these can be tricky.
+these can be tricky, however, the following instructions should work. If they
+don't, or are not explicit enough, please open an issue.
 
-### Pardiso Project
+### Pardiso (Pardiso Project)
 
 #### Linux
 
-Tested on a clean install of Ubuntu 20.04.
+_Tested on a clean install of Ubuntu 20.04._
 
 1. Install lapack and libomp:
    ```
@@ -135,9 +136,25 @@ Tested on a clean install of Ubuntu 20.04.
 
 Currently untested. If you have instructions that work, please open an issue.
 
-### MA27
+### Pardiso (MKL)
 
 #### Linux
+
+Currently untested. If you have instructions that work, please open an issue.
+
+#### Mac
+
+Currently untested. If you have instructions that work, please open an issue.
+
+#### Windows
+
+Currently untested. If you have instructions that work, please open an issue.
+
+### HSL (MA27)
+
+#### Linux
+
+_Tested on a clean install of Ubuntu 20.04._
 
 1. Install Fortran compiler if necessary
    ```
@@ -182,6 +199,20 @@ Currently untested. If you have instructions that work, please open an issue.
    model = Model(Ipopt.Optimizer)
    set_optimizer_attribute(model, "linear_solver", "ma27")
    ```
+
+#### Windows
+
+Currently untested. If you have instructions that work, please open an issue.
+
+### HSL (MA86, MA97)
+
+#### Linux
+
+Currently untested. If you have instructions that work, please open an issue.
+
+#### Mac
+
+Currently untested. If you have instructions that work, please open an issue.
 
 #### Windows
 

--- a/README.md
+++ b/README.md
@@ -67,22 +67,36 @@ model = Model(Ipopt.Optimizer)
 **Note: it is not necessary to compile a custom version of Ipopt to use a
 different linear solver. See the Linear Solvers section below.**
 
-To install custom built Ipopt binaries set the environmental variables
-`JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`, and call
-`import Pkg; Pkg.build("Ipopt")`. For instance, if the libraries are installed
-in `/opt/lib` and the executable is in `/opt/bin` just call
+To install custom built Ipopt binaries, you must compile the shared library (
+e.g., `libipopt.dylib`, `libipopt.so`, or `libipopt.dll`) _and_ the AMPL
+executable (e.g., `ipopt` or `ipopt.exe`).
+
+If you cannot compile the AMPL executable, you can [download an appropriate
+version from AMPL](https://ampl.com/products/solvers/open-source/#ipopt).
+
+Next, set the environmental variables `JULIA_IPOPT_LIBRARY_PATH` and
+`JULIA_IPOPT_EXECUTABLE_PATH` to point the the shared library and AMPL
+executable repspectively. Then call `import Pkg; Pkg.build("Ipopt")`.
+
+For instance, given `/Users/oscar/lib/libipopt.dylib` and
+`/Users/oscar/bin/ipopt`, run:
 ```julia
-ENV["JULIA_IPOPT_LIBRARY_PATH"] = "/opt/lib"
-ENV["JULIA_IPOPT_EXECUTABLE_PATH"] = "/opt/bin"
-import Pkg; Pkg.build("Ipopt")
+ENV["JULIA_IPOPT_LIBRARY_PATH"] = "/home/oscar/lib"
+ENV["JULIA_IPOPT_EXECUTABLE_PATH"] = "/home/oscar/bin"
+import Pkg
+Pkg.build("Ipopt")
 ```
 
-If you do not want BinaryProvider to download the default binaries on install
-set  `JULIA_IPOPT_LIBRARY_PATH` and `JULIA_IPOPT_EXECUTABLE_PATH`  before
-calling `import Pkg; Pkg.add("Ipopt")`.
+**Very important note: before calling `using Ipopt` in any Julia session, you
+must set these environment variables.**
 
-To switch back to the default binaries clear `JULIA_IPOPT_LIBRARY_PATH` and
-`JULIA_IPOPT_EXECUTABLE_PATH`, and call `import Pkg; Pkg.build("Ipopt")`.
+To switch back to the default binaries, run
+```julia
+delete!(ENV, "JULIA_IPOPT_LIBRARY_PATH")
+delete!(ENV, "JULIA_IPOPT_EXECUTABLE_PATH")
+import Pkg
+Pkg.build("Ipopt")
+```
 
 ## Linear Solvers
 
@@ -119,6 +133,8 @@ _Tested on a clean install of Ubuntu 20.04._
    ```
 
 #### Mac
+
+_Tested on a MacBook Pro, 10.15.7._
 
 1. Download Pardiso from [https://www.pardiso-project.org](https://www.pardiso-project.org)
 2. Rename the file `libpardiso-XXXXX.dylib` to `libpardiso.dylib`, and place it
@@ -180,6 +196,8 @@ _Tested on a clean install of Ubuntu 20.04._
    ```
 
 #### Mac
+
+_Tested on a MacBook Pro, 10.15.7._
 
 1. Download HSL for IPOPT from http://www.hsl.rl.ac.uk/ipopt/
 2. Unzip the download, and run the following:

--- a/README.md
+++ b/README.md
@@ -93,16 +93,43 @@ these can be tricky.
 
 #### Linux
 
-Currently untested. If you have instructions that work, please open an issue.
+Tested on a clean install of Ubuntu 20.04.
+
+1. Install lapack and libomp:
+   ```
+   sudo apt install liblapack3 libomp-dev
+   ```
+2. Download Pardiso from [https://www.pardiso-project.org](https://www.pardiso-project.org)
+3. Rename the file `libpardiso-XXXXX.so` to `libpardiso.so`, and place it
+   somewhere on your load path.
+   - Alternatively, if the library is located at `/full/path/libpardiso.dylib`,
+     start Julia with `export LD_LIBRARY_PATH=/full/path; julia`
+4. Set the option `linear_solver` to `pardiso`:
+   ```julia
+   using Libdl
+   # Note: these filenames may differ. Check `/usr/lib/x86_64-linux-gnu` for the
+   # specific extension.
+   Libdl.dlopen("/usr/lib/x86_64-linux-gnu/liblapack.so.3", RTLD_GLOBAL)
+   Libdl.dlopen("/usr/lib/x86_64-linux-gnu/libomp.so.5", RTLD_GLOBAL)
+
+   using JuMP, Ipopt
+   model = Model(Ipopt.Optimizer)
+   set_optimizer_attribute(model, "linear_solver", "pardiso")
+   ```
 
 #### Mac
 
 1. Download Pardiso from [https://www.pardiso-project.org](https://www.pardiso-project.org)
 2. Rename the file `libpardiso-XXXXX.dylib` to `libpardiso.dylib`, and place it
    somewhere on your load path.
-    - Alternatively, if the library is located at `/full/path/libpardiso.dylib`,
-      start Julia with `export LD_LOAD_PATH=/full/path; julia`
-4. Set the option `set_optimizer_attribute(model, "linear_solver", "pardiso")`
+   - Alternatively, if the library is located at `/full/path/libpardiso.dylib`,
+     start Julia with `export LD_LOAD_PATH=/full/path; julia`
+4. Set the option `linear_solver` to `pardiso`:
+   ```julia
+   using JuMP, Ipopt
+   model = Model(Ipopt.Optimizer)
+   set_optimizer_attribute(model, "linear_solver", "pardiso")
+   ```
 
 #### Windows
 
@@ -118,16 +145,21 @@ Currently untested. If you have instructions that work, please open an issue.
 
 1. Download HSL for IPOPT from http://www.hsl.rl.ac.uk/ipopt/
 2. Unzip the download, and run the following:
-    ```
-    ./configure --prefix=</full/path/somewhere>
-    make
-    ```
-    where `</full/path/somewhere>` is replaced as appropriate.
+   ```
+   ./configure --prefix=</full/path/somewhere>
+   make
+   ```
+   where `</full/path/somewhere>` is replaced as appropriate.
 3. Rename the files `/full/path/somewhere/lib/libcoinhsl.dylib` to
-    `/full/path/somewhere/lib/libhsl.dylib`, and place the library somewhere on
-    your load path.
-    - Alternatively, start Julia with `export LD_LOAD_PATH=/full/path/somewhere/lib; julia`
-4. Set the option `set_optimizer_attribute(model, "linear_solver", "ma27")`
+   `/full/path/somewhere/lib/libhsl.dylib`, and place the library somewhere on
+   your load path.
+   - Alternatively, start Julia with `export LD_LOAD_PATH=/full/path/somewhere/lib; julia`
+4. Set the option `linear_solver` to `ma27`:
+   ```julia
+   using JuMP, Ipopt
+   model = Model(Ipopt.Optimizer)
+   set_optimizer_attribute(model, "linear_solver", "ma27")
+   ```
 
 #### Windows
 


### PR DESCRIPTION
There are a lot of open issues relating to linear solvers with Ipopt. The installation instructions for this are non-existent, so here is an attempt. I don't have a Windows machine, so if people can chime in with instructions that work on Windows, that would be helpful.

The easiest way forward is almost certainly to use the `Ipopt_jll` binaries with the `linear_solver` loading. However, Ipopt hard-codes the library names, which causes most of the difficulties.

Here are solver/platform combinations I have tested and got working so far:

* Pardiso Project
  - [ ] Windows
  - [x] Mac
  - [x] Linux  (#106, #177)
* MKL Pardiso
  - [ ] Windows
  - [ ] Mac
  - [ ] Linux (#195)
* HSL for Ipopt (MA27)
  - [ ] Windows (#229)
  - [x] Mac
  - [x] Linux
* HSL (MA86, MA97)
  - [ ] Windows (#192)
  - [ ] Mac (#197, #213)
  - [ ] Linux

I have also updated the instructions for compiling a custom library. (#78, #197, #229 )