### PR TITLE
DNMY: pin MUMPS to see if it passes tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ BinaryProvider = "0.5.9"
 Ipopt_jll = "3.13.1"
 MathOptInterface = "~0.9.5"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
-MUMPS_seq_jll = "5.2"
+MUMPS_seq_jll = "=5.2"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ BinaryProvider = "0.5.9"
 Ipopt_jll = "3.13.1"
 MathOptInterface = "~0.9.5"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
-MUMPS_seq_jll = "=5.2"
+MUMPS_seq_jll = "=5.2.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MUMPS_seq_jll = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 MathProgBase = "fdba3010-5040-5b88-9595-932c9decdf73"
 
@@ -16,6 +17,7 @@ BinaryProvider = "0.5.9"
 Ipopt_jll = "3.13.1"
 MathOptInterface = "~0.9.5"
 MathProgBase = "~0.5.0, ~0.6, ~0.7"
+MUMPS_seq_jll = "5.2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
x-ref: #242 

@dpo, it looks like `MUMPS_seq_jll` 5.3.5 broke Ipopt: https://github.com/JuliaPackaging/Yggdrasil/pull/2136

We may need to put some compat bounds in the Ipopt_jll Yggdrasil build script: https://github.com/JuliaPackaging/Yggdrasil/blob/81ba5b59fb9864d4dbccbe1abe49bb0e15131ab4/I/Ipopt/build_tarballs.jl#L50-L51