### PR TITLE
[breaking] remove ability to access binary from Ipopt.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ipopt"
 uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 repo = "https://github.com/jump-dev/Ipopt.jl.git"
-version = "0.6.5"
+version = "0.7.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+**Ipopt.jl 0.7 contains breaking changes.**
+
+**Access to the binary via `amplexe` and `amplexefun` has been removed because
+it required an initialization that caused problems with other packages.**
+ - **On Julia 1.3 or later, use `Ipopt_jll.amplexe` instead.**
+ - **On Julia 1.0, install Ipopt.jl version 0.6.x via `] add Ipopt@0.6`. Make
+   sure to restart Julia for the changes to take effect.**
+
 # Ipopt.jl
 
 ![](https://www.coin-or.org/wordpress/wp-content/uploads/2014/08/COINOR.png)

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -203,11 +203,6 @@ function test_hs071()
     return rm("blah.txt")
 end
 
-function test_binary()
-    # Test that the ipopt binary works
-    @test Ipopt.amplexefun("-v") == 0
-end
-
 end  # TestCWrapper
 
 runtests(TestCWrapper)


### PR DESCRIPTION
This PR removes `amplexefun` and related things. In particular, the `__init__` method broke other packages by modifying `LD_LIBRARY_PATH`. Instead of providing a nice deprecation, it just throws an error. 

The original motivation for this was to provide a nice way to call the Ipopt binary for things like AmplNLWriter. Now that we have Ipopt_jll, Ipopt.jl no longer needs to do this job.

One exception is on Julia 1.0, but then we can just tell people to use `Ipopt.jl@0.6`.

Closes #261 