### PR TITLE
Add option Maximum_WallTime_Exceeded

### DIFF
--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -107,6 +107,7 @@ const ApplicationReturnStatus = Dict(
     -2 => :Restoration_Failed,
     -3 => :Error_In_Step_Computation,
     -4 => :Maximum_CpuTime_Exceeded,
+    -5 => :Maximum_WallTime_Exceeded,
     -10 => :Not_Enough_Degrees_Of_Freedom,
     -11 => :Invalid_Problem_Definition,
     -12 => :Invalid_Option,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1737,6 +1737,8 @@ function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
         return MOI.ITERATION_LIMIT
     elseif status == :Maximum_CpuTime_Exceeded
         return MOI.TIME_LIMIT
+    elseif status == :Maximum_WallTime_Exceeded
+        return MOI.TIME_LIMIT
     elseif status == :Restoration_Failed
         return MOI.NUMERICAL_ERROR
     elseif status == :Error_In_Step_Computation


### PR DESCRIPTION
Add the new Ipopt option Maximum_WallTime_Exceeded, available since version 3.14.0. See [here](https://github.com/coin-or/Ipopt/blob/e4f829e7263cd05e55eafc3077edd05871f1ed21/src/Interfaces/IpReturnCodes_inc.h#L27).