### PR TITLE
Fix edge cases for RawStatusString

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1311,7 +1311,13 @@ end
 ### MOI.RawStatusString
 
 function MOI.get(model::Optimizer, ::MOI.RawStatusString)
-    return string(_STATUS_CODES[model.inner.status])
+    if model.invalid_model
+        return "The model has no variable"
+    elseif model.inner === nothing
+        return "Optimize not called"
+    else
+        return string(_STATUS_CODES[model.inner.status])
+    end
 end
 
 ### MOI.PrimalStatus

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -184,7 +184,7 @@ end
 
 function test_empty_optimize()
     model = Ipopt.Optimizer()
-    @test MOI.get(model, MOI.RawStatusString()) == "The model has no variable"
+    @test MOI.get(model, MOI.RawStatusString()) == "Optimize not called"
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INVALID_MODEL
     @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -184,10 +184,12 @@ end
 
 function test_empty_optimize()
     model = Ipopt.Optimizer()
+    @test MOI.get(model, MOI.RawStatusString()) == "The model has no variable"
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INVALID_MODEL
     @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
     @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.RawStatusString()) == "The model has no variable"
     return
 end
 


### PR DESCRIPTION
This would produce errors, e.g., when using `JuMP.solution_summary`.