### PR TITLE
Update inner.x more often in callback

### DIFF
--- a/src/C_wrapper.jl
+++ b/src/C_wrapper.jl
@@ -53,8 +53,7 @@ end
 function _Eval_G_CB(
     n::Cint,
     x_ptr::Ptr{Float64},
-    # A Bool indicating if `x` is a new point. We don't make use of this.
-    ::Cint,
+    x_new::Cint,
     m::Cint,
     g_ptr::Ptr{Float64},
     user_data::Ptr{Cvoid},
@@ -62,6 +61,9 @@ function _Eval_G_CB(
     prob = unsafe_pointer_to_objref(user_data)::IpoptProblem
     new_g = unsafe_wrap(Array, g_ptr, Int(m))
     x = unsafe_wrap(Array, x_ptr, Int(n))
+    if x_new == Cint(1)
+        prob.x .= x
+    end
     prob.eval_g(x, new_g)
     return Cint(1)
 end


### PR DESCRIPTION
Closes https://github.com/jump-dev/Ipopt.jl/issues/308

<s>Bit hard to test this, but:</s>
```Julia
julia> using JuMP, Ipopt

julia> model = Model(Ipopt.Optimizer);

julia> set_silent(model)

julia> @variable(model, 0 <= x <= 1, start = 0.1)
x

julia> @objective(model, Min, x^2)
x²

julia> @NLconstraint(model, x^3 >= 0)
x ^ 3.0 - 0.0 ≥ 0

julia> function callback(args...)
           println(callback_value(model, x))
           return true
       end
callback (generic function with 1 method)

julia> MOI.set(model, Ipopt.CallbackFunction(), callback)

julia> optimize!(model)

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit https://github.com/coin-or/Ipopt
******************************************************************************

0.1
0.10514188365412411
0.07016157841557216
0.04934083913488038
0.034372754296446165
0.026335886555989847
0.019465669225666605
0.017808440686808424
0.011915435614467111
0.00802217171906363
0.005336291057813261
0.0036331258221849955
0.0023247611846039943
0.0013819230980523034
0.0007710101613253921
0.001097374417621643
0.00024836666226348675
0.0001787055276186702
0.00010852806714208063
5.995968618266994e-5
```