### PR TITLE
Refactor linear/quadratic model handling

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -118,7 +118,7 @@ end
 
 function MOI.get(model::Optimizer, attr::MOI.ListOfConstraintTypesPresent)
     ret = MOI.get(model.variables, attr)
-    append!(MOI.get(model.qp_data, attr))
+    append!(ret, MOI.get(model.qp_data, attr))
     return ret
 end
 

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -3,13 +3,7 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-mutable struct _ConstraintInfo{F,S}
-    func::F
-    set::S
-    dual_start::Union{Nothing,Float64}
-end
-
-_ConstraintInfo(func, set) = _ConstraintInfo(func, set, nothing)
+include("utils.jl")
 
 """
     Optimizer()
@@ -20,56 +14,22 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     inner::Union{Nothing,IpoptProblem}
     name::String
     invalid_model::Bool
-    variables::MOI.Utilities.VariablesContainer{Float64}
-    variable_primal_start::Vector{Union{Nothing,Float64}}
-    variable_lower_start::Vector{Union{Nothing,Float64}}
-    variable_upper_start::Vector{Union{Nothing,Float64}}
-    nlp_data::MOI.NLPBlockData
-    nlp_data_needs_initialize::Bool
-    sense::MOI.OptimizationSense
-    objective::Union{
-        Nothing,
-        MOI.VariableIndex,
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    }
-    linear_le_constraints::Vector{
-        _ConstraintInfo{
-            MOI.ScalarAffineFunction{Float64},
-            MOI.LessThan{Float64},
-        },
-    }
-    linear_ge_constraints::Vector{
-        _ConstraintInfo{
-            MOI.ScalarAffineFunction{Float64},
-            MOI.GreaterThan{Float64},
-        },
-    }
-    linear_eq_constraints::Vector{
-        _ConstraintInfo{MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}},
-    }
-    quadratic_le_constraints::Vector{
-        _ConstraintInfo{
-            MOI.ScalarQuadraticFunction{Float64},
-            MOI.LessThan{Float64},
-        },
-    }
-    quadratic_ge_constraints::Vector{
-        _ConstraintInfo{
-            MOI.ScalarQuadraticFunction{Float64},
-            MOI.GreaterThan{Float64},
-        },
-    }
-    quadratic_eq_constraints::Vector{
-        _ConstraintInfo{
-            MOI.ScalarQuadraticFunction{Float64},
-            MOI.EqualTo{Float64},
-        },
-    }
-    nlp_dual_start::Union{Nothing,Vector{Float64}}
     silent::Bool
     options::Dict{String,Any}
     solve_time::Float64
+    sense::MOI.OptimizationSense
+
+    variables::MOI.Utilities.VariablesContainer{Float64}
+    variable_primal_start::Vector{Union{Nothing,Float64}}
+    mult_x_L::Vector{Union{Nothing,Float64}}
+    mult_x_U::Vector{Union{Nothing,Float64}}
+
+    nlp_data::MOI.NLPBlockData
+    nlp_data_needs_initialize::Bool
+    nlp_dual_start::Union{Nothing,Vector{Float64}}
+
+    linear::LinearQuadraticConstraintBlock{Float64}
+
     callback::Union{Nothing,Function}
 
     function Optimizer()
@@ -77,46 +37,30 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             nothing,
             "",
             false,
+            false,
+            Dict{String,Any}(),
+            NaN,
+            MOI.FEASIBILITY_SENSE,
             MOI.Utilities.VariablesContainer{Float64}(),
             Union{Nothing,Float64}[],
             Union{Nothing,Float64}[],
             Union{Nothing,Float64}[],
             MOI.NLPBlockData([], _EmptyNLPEvaluator(), false),
             true,
-            MOI.FEASIBILITY_SENSE,
             nothing,
-            _ConstraintInfo{
-                MOI.ScalarAffineFunction{Float64},
-                MOI.LessThan{Float64},
-            }[],
-            _ConstraintInfo{
-                MOI.ScalarAffineFunction{Float64},
-                MOI.GreaterThan{Float64},
-            }[],
-            _ConstraintInfo{
-                MOI.ScalarAffineFunction{Float64},
-                MOI.EqualTo{Float64},
-            }[],
-            _ConstraintInfo{
-                MOI.ScalarQuadraticFunction{Float64},
-                MOI.LessThan{Float64},
-            }[],
-            _ConstraintInfo{
-                MOI.ScalarQuadraticFunction{Float64},
-                MOI.GreaterThan{Float64},
-            }[],
-            _ConstraintInfo{
-                MOI.ScalarQuadraticFunction{Float64},
-                MOI.EqualTo{Float64},
-            }[],
-            nothing,
-            false,
-            Dict{String,Any}(),
-            NaN,
+            LinearQuadraticConstraintBlock{Float64}(),
             nothing,
         )
     end
 end
+
+const _SETS =
+    Union{MOI.GreaterThan{Float64},MOI.LessThan{Float64},MOI.EqualTo{Float64}}
+
+const _FUNCTIONS = Union{
+    MOI.ScalarAffineFunction{Float64},
+    MOI.ScalarQuadraticFunction{Float64},
+}
 
 MOI.get(::Optimizer, ::MOI.SolverVersion) = "3.14.4"
 
@@ -135,36 +79,26 @@ MOI.eval_hessian_lagrangian(::_EmptyNLPEvaluator, H, x, σ, μ) = nothing
 function MOI.empty!(model::Optimizer)
     model.inner = nothing
     model.invalid_model = false
+    model.sense = MOI.FEASIBILITY_SENSE
     MOI.empty!(model.variables)
     empty!(model.variable_primal_start)
-    empty!(model.variable_lower_start)
-    empty!(model.variable_upper_start)
+    empty!(model.mult_x_L)
+    empty!(model.mult_x_U)
     model.nlp_data = MOI.NLPBlockData([], _EmptyNLPEvaluator(), false)
-    model.sense = MOI.FEASIBILITY_SENSE
-    model.objective = nothing
-    empty!(model.linear_le_constraints)
-    empty!(model.linear_ge_constraints)
-    empty!(model.linear_eq_constraints)
-    empty!(model.quadratic_le_constraints)
-    empty!(model.quadratic_ge_constraints)
-    empty!(model.quadratic_eq_constraints)
+    model.nlp_data_needs_initialize = true
     model.nlp_dual_start = nothing
+    model.linear = LinearQuadraticConstraintBlock{Float64}()
+    model.callback = nothing
     return
 end
 
 function MOI.is_empty(model::Optimizer)
     return MOI.is_empty(model.variables) &&
            isempty(model.variable_primal_start) &&
-           isempty(model.variable_lower_start) &&
-           isempty(model.variable_upper_start) &&
+           isempty(model.mult_x_L) &&
+           isempty(model.mult_x_U) &&
            model.nlp_data.evaluator isa _EmptyNLPEvaluator &&
-           model.sense == MOI.FEASIBILITY_SENSE &&
-           isempty(model.linear_le_constraints) &&
-           isempty(model.linear_ge_constraints) &&
-           isempty(model.linear_eq_constraints) &&
-           isempty(model.quadratic_le_constraints) &&
-           isempty(model.quadratic_ge_constraints) &&
-           isempty(model.quadratic_eq_constraints)
+           model.sense == MOI.FEASIBILITY_SENSE
 end
 
 MOI.supports_incremental_interface(::Optimizer) = true
@@ -177,42 +111,18 @@ MOI.get(::Optimizer, ::MOI.SolverName) = "Ipopt"
 
 function MOI.supports_constraint(
     ::Optimizer,
-    ::Type{
-        <:Union{
-            MOI.VariableIndex,
-            MOI.ScalarAffineFunction{Float64},
-            MOI.ScalarQuadraticFunction{Float64},
-        },
-    },
-    ::Type{
-        <:Union{
-            MOI.LessThan{Float64},
-            MOI.GreaterThan{Float64},
-            MOI.EqualTo{Float64},
-        },
-    },
+    ::Type{<:Union{MOI.VariableIndex,_FUNCTIONS}},
+    ::Type{<:_SETS},
 )
     return true
 end
 
-function MOI.get(model::Optimizer, ::MOI.ListOfConstraintTypesPresent)
-    ret = MOI.get(model.variables, MOI.ListOfConstraintTypesPresent())
-    constraints = Set{Tuple{Type,Type}}()
-    for F in (
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    )
-        for S in (
-            MOI.LessThan{Float64},
-            MOI.GreaterThan{Float64},
-            MOI.EqualTo{Float64},
-        )
-            if !isempty(_constraints(model, F, S))
-                push!(constraints, (F, S))
-            end
-        end
-    end
-    return append!(ret, collect(constraints))
+### MOI.ListOfConstraintTypesPresent
+
+function MOI.get(model::Optimizer, attr::MOI.ListOfConstraintTypesPresent)
+    ret = MOI.get(model.variables, attr)
+    append!(MOI.get(model.linear, attr))
+    return ret
 end
 
 ### MOI.Name
@@ -282,8 +192,8 @@ column(x::MOI.VariableIndex) = x.value
 
 function MOI.add_variable(model::Optimizer)
     push!(model.variable_primal_start, nothing)
-    push!(model.variable_lower_start, nothing)
-    push!(model.variable_upper_start, nothing)
+    push!(model.mult_x_L, nothing)
+    push!(model.mult_x_U, nothing)
     return MOI.add_variable(model.variables)
 end
 
@@ -300,38 +210,30 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    ci::MOI.ConstraintIndex{MOI.VariableIndex,S},
-) where {S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}}
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,<:_SETS},
+)
     return MOI.is_valid(model.variables, ci)
 end
 
 function MOI.get(
     model::Optimizer,
     attr::Union{
-        MOI.NumberOfConstraints{MOI.VariableIndex,S},
-        MOI.ListOfConstraintIndices{MOI.VariableIndex,S},
+        MOI.NumberOfConstraints{MOI.VariableIndex,<:_SETS},
+        MOI.ListOfConstraintIndices{MOI.VariableIndex,<:_SETS},
     },
-) where {S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}}
+)
     return MOI.get(model.variables, attr)
 end
 
 function MOI.get(
     model::Optimizer,
     attr::Union{MOI.ConstraintFunction,MOI.ConstraintSet},
-    c::MOI.ConstraintIndex{MOI.VariableIndex,S},
-) where {S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}}
+    c::MOI.ConstraintIndex{MOI.VariableIndex,<:_SETS},
+)
     return MOI.get(model.variables, attr, c)
 end
 
-function MOI.add_constraint(
-    model::Optimizer,
-    x::MOI.VariableIndex,
-    set::Union{
-        MOI.LessThan{Float64},
-        MOI.GreaterThan{Float64},
-        MOI.EqualTo{Float64},
-    },
-)
+function MOI.add_constraint(model::Optimizer, x::MOI.VariableIndex, set::_SETS)
     return MOI.add_constraint(model.variables, x, set)
 end
 
@@ -340,15 +242,15 @@ function MOI.set(
     ::MOI.ConstraintSet,
     ci::MOI.ConstraintIndex{MOI.VariableIndex,S},
     set::S,
-) where {S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}}
+) where {S<:_SETS}
     MOI.set(model.variables, MOI.ConstraintSet(), ci, set)
     return
 end
 
 function MOI.delete(
     model::Optimizer,
-    ci::MOI.ConstraintIndex{MOI.VariableIndex,S},
-) where {S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo}}
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,<:_SETS},
+)
     MOI.delete(model.variables, ci)
     return
 end
@@ -357,208 +259,51 @@ end
 
 function MOI.is_valid(
     model::Optimizer,
-    ci::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S<:Union{MOI.LessThan,MOI.GreaterThan,MOI.EqualTo},
-}
-    return 1 <= ci.value <= length(_constraints(model, F, S))
-end
-
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarAffineFunction{Float64}},
-    ::Type{MOI.LessThan{Float64}},
+    ci::MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS},
 )
-    return model.linear_le_constraints
+    return MOI.is_valid(model.linear, ci)
 end
 
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarAffineFunction{Float64}},
-    ::Type{MOI.GreaterThan{Float64}},
-)
-    return model.linear_ge_constraints
-end
-
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarAffineFunction{Float64}},
-    ::Type{MOI.EqualTo{Float64}},
-)
-    return model.linear_eq_constraints
-end
-
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarQuadraticFunction{Float64}},
-    ::Type{MOI.LessThan{Float64}},
-)
-    return model.quadratic_le_constraints
-end
-
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarQuadraticFunction{Float64}},
-    ::Type{MOI.GreaterThan{Float64}},
-)
-    return model.quadratic_ge_constraints
-end
-
-function _constraints(
-    model::Optimizer,
-    ::Type{MOI.ScalarQuadraticFunction{Float64}},
-    ::Type{MOI.EqualTo{Float64}},
-)
-    return model.quadratic_eq_constraints
-end
-
-function _check_inbounds(model::Optimizer, var::MOI.VariableIndex)
-    MOI.throw_if_not_valid(model, var)
-    return
-end
-
-function _check_inbounds(model::Optimizer, aff::MOI.ScalarAffineFunction)
-    for term in aff.terms
-        MOI.throw_if_not_valid(model, term.variable)
-    end
-    return
-end
-
-function _check_inbounds(model::Optimizer, quad::MOI.ScalarQuadraticFunction)
-    for term in quad.affine_terms
-        MOI.throw_if_not_valid(model, term.variable)
-    end
-    for term in quad.quadratic_terms
-        MOI.throw_if_not_valid(model, term.variable_1)
-        MOI.throw_if_not_valid(model, term.variable_2)
-    end
-    return
-end
-
-function MOI.add_constraint(
-    model::Optimizer,
-    func::F,
-    set::S,
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S<:MOI.AbstractScalarSet,
-}
-    _check_inbounds(model, func)
-    constraints = _constraints(model, F, S)
-    push!(constraints, _ConstraintInfo(func, set))
-    return MOI.ConstraintIndex{F,S}(length(constraints))
+function MOI.add_constraint(model::Optimizer, func::_FUNCTIONS, set::_SETS)
+    return MOI.add_constraint(model.linear, func, set)
 end
 
 function MOI.get(
     model::Optimizer,
-    ::MOI.NumberOfConstraints{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
-    return length(_constraints(model, F, S))
+    attr::Union{MOI.NumberOfConstraints{F,S},MOI.ListOfConstraintIndices{F,S}},
+) where {F<:_FUNCTIONS,S<:_SETS}
+    return MOI.get(model.linear, attr)
 end
 
 function MOI.get(
     model::Optimizer,
-    ::MOI.ListOfConstraintIndices{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
+    attr::Union{
+        MOI.ConstraintFunction,
+        MOI.ConstraintSet,
+        MOI.ConstraintDualStart,
     },
-    S,
-}
-    return MOI.ConstraintIndex{F,S}[
-        MOI.ConstraintIndex{F,S}(i) for
-        i in eachindex(_constraints(model, F, S))
-    ]
-end
-
-function MOI.get(
-    model::Optimizer,
-    ::MOI.ConstraintFunction,
     c::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
-    return _constraints(model, F, S)[c.value].func
-end
-
-function MOI.get(
-    model::Optimizer,
-    ::MOI.ConstraintSet,
-    c::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
-    return _constraints(model, F, S)[c.value].set
+) where {F<:_FUNCTIONS,S<:_SETS}
+    return MOI.get(model.linear, attr, c)
 end
 
 function MOI.supports(
     ::Optimizer,
     ::MOI.ConstraintDualStart,
     ::Type{MOI.ConstraintIndex{F,S}},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
+) where {F<:_FUNCTIONS,S<:_SETS}
     return true
 end
 
 function MOI.set(
     model::Optimizer,
-    ::MOI.ConstraintDualStart,
+    attr::MOI.ConstraintDualStart,
     ci::MOI.ConstraintIndex{F,S},
     value::Union{Real,Nothing},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
+) where {F<:_FUNCTIONS,S<:_SETS}
     MOI.throw_if_not_valid(model, ci)
-    constraints = _constraints(model, F, S)
-    constraints[ci.value].dual_start = value
+    MOI.set(model.linear, attr, ci, value)
     return
-end
-
-function MOI.get(
-    model::Optimizer,
-    ::MOI.ConstraintDualStart,
-    ci::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
-    MOI.throw_if_not_valid(model, ci)
-    constraints = _constraints(model, F, S)
-    return constraints[ci.value].dual_start
 end
 
 ### MOI.VariablePrimalStart
@@ -593,12 +338,7 @@ end
 function MOI.supports(
     ::Optimizer,
     ::MOI.ConstraintDualStart,
-    ::Type{
-        MOI.ConstraintIndex{
-            MOI.VariableIndex,
-            <:Union{MOI.GreaterThan,MOI.LessThan,MOI.EqualTo},
-        },
-    },
+    ::Type{MOI.ConstraintIndex{MOI.VariableIndex,<:_SETS}},
 )
     return true
 end
@@ -610,7 +350,7 @@ function MOI.set(
     value::Union{Real,Nothing},
 )
     MOI.throw_if_not_valid(model, ci)
-    model.variable_lower_start[ci.value] = value
+    model.mult_x_L[ci.value] = value
     return
 end
 
@@ -620,7 +360,7 @@ function MOI.get(
     ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{Float64}},
 )
     MOI.throw_if_not_valid(model, ci)
-    return model.variable_lower_start[ci.value]
+    return model.mult_x_L[ci.value]
 end
 
 function MOI.set(
@@ -630,7 +370,7 @@ function MOI.set(
     value::Union{Real,Nothing},
 )
     MOI.throw_if_not_valid(model, ci)
-    model.variable_upper_start[ci.value] = value
+    model.mult_x_U[ci.value] = value
     return
 end
 
@@ -640,7 +380,7 @@ function MOI.get(
     ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.LessThan{Float64}},
 )
     MOI.throw_if_not_valid(model, ci)
-    return model.variable_upper_start[ci.value]
+    return model.mult_x_U[ci.value]
 end
 
 function MOI.set(
@@ -651,14 +391,14 @@ function MOI.set(
 )
     MOI.throw_if_not_valid(model, ci)
     if value === nothing
-        model.variable_lower_start[ci.value] = nothing
-        model.variable_upper_start[ci.value] = nothing
+        model.mult_x_L[ci.value] = nothing
+        model.mult_x_U[ci.value] = nothing
     elseif value >= 0.0
-        model.variable_lower_start[ci.value] = value
-        model.variable_upper_start[ci.value] = 0.0
+        model.mult_x_L[ci.value] = value
+        model.mult_x_U[ci.value] = 0.0
     else
-        model.variable_lower_start[ci.value] = 0.0
-        model.variable_upper_start[ci.value] = value
+        model.mult_x_L[ci.value] = 0.0
+        model.mult_x_U[ci.value] = value
     end
     return
 end
@@ -669,8 +409,8 @@ function MOI.get(
     ci::MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}},
 )
     MOI.throw_if_not_valid(model, ci)
-    l = model.variable_lower_start[ci.value]
-    u = model.variable_upper_start[ci.value]
+    l = model.mult_x_L[ci.value]
+    u = model.mult_x_U[ci.value]
     return (l === u === nothing) ? nothing : (l + u)
 end
 
@@ -716,379 +456,104 @@ MOI.get(model::Optimizer, ::MOI.ObjectiveSense) = model.sense
 
 ### ObjectiveFunction
 
-MOI.get(model::Optimizer, ::MOI.ObjectiveFunctionType) = typeof(model.objective)
-
-function MOI.get(model::Optimizer, ::MOI.ObjectiveFunction{F}) where {F}
-    return convert(F, model.objective)::F
+function MOI.get(
+    model::Optimizer,
+    attr::Union{MOI.ObjectiveFunctionType,MOI.ObjectiveFunction},
+)
+    return MOI.get(model.linear, attr)
 end
 
 function MOI.supports(
     ::Optimizer,
-    ::MOI.ObjectiveFunction{
-        <:Union{
-            MOI.VariableIndex,
-            MOI.ScalarAffineFunction{Float64},
-            MOI.ScalarQuadraticFunction{Float64},
-        },
-    },
+    ::MOI.ObjectiveFunction{<:Union{MOI.VariableIndex,<:_FUNCTIONS}},
 )
     return true
 end
 
 function MOI.set(
     model::Optimizer,
-    ::MOI.ObjectiveFunction{F},
+    attr::MOI.ObjectiveFunction{F},
     func::F,
-) where {
-    F<:Union{
-        MOI.VariableIndex,
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-}
-    _check_inbounds(model, func)
-    model.objective = func
+) where {F<:Union{MOI.VariableIndex,<:_FUNCTIONS}}
+    MOI.set(model.linear, attr, func)
     return
 end
 
-### Ipopt callback functions
-### In setting up the data for Ipopt, we order the constraints as follows:
-### - linear_le_constraints
-### - linear_ge_constraints
-### - linear_eq_constraints
-### - quadratic_le_constraints
-### - quadratic_ge_constraints
-### - quadratic_eq_constraints
-### - nonlinear constraints from nlp_data
-
-const _CONSTRAINT_ORDERING = (
-    :linear_le_constraints,
-    :linear_ge_constraints,
-    :linear_eq_constraints,
-    :quadratic_le_constraints,
-    :quadratic_ge_constraints,
-    :quadratic_eq_constraints,
-)
-
-function _offset(
-    ::Optimizer,
-    ::Type{<:MOI.ScalarAffineFunction},
-    ::Type{<:MOI.LessThan},
-)
-    return 0
-end
-
-function _offset(
-    model::Optimizer,
-    ::Type{<:MOI.ScalarAffineFunction},
-    ::Type{<:MOI.GreaterThan},
-)
-    return length(model.linear_le_constraints)
-end
-
-function _offset(
-    model::Optimizer,
-    F::Type{<:MOI.ScalarAffineFunction},
-    ::Type{<:MOI.EqualTo},
-)
-    return _offset(model, F, MOI.GreaterThan{Float64}) +
-           length(model.linear_ge_constraints)
-end
-
-function _offset(
-    model::Optimizer,
-    ::Type{<:MOI.ScalarQuadraticFunction},
-    ::Type{<:MOI.LessThan},
-)
-    x = _offset(model, MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})
-    return x + length(model.linear_eq_constraints)
-end
-
-function _offset(
-    model::Optimizer,
-    F::Type{<:MOI.ScalarQuadraticFunction},
-    ::Type{<:MOI.GreaterThan},
-)
-    return _offset(model, F, MOI.LessThan{Float64}) +
-           length(model.quadratic_le_constraints)
-end
-
-function _offset(
-    model::Optimizer,
-    F::Type{<:MOI.ScalarQuadraticFunction},
-    ::Type{<:MOI.EqualTo},
-)
-    return _offset(model, F, MOI.GreaterThan{Float64}) +
-           length(model.quadratic_ge_constraints)
-end
-
-function _nlp_constraint_offset(model::Optimizer)
-    x = _offset(
-        model,
-        MOI.ScalarQuadraticFunction{Float64},
-        MOI.EqualTo{Float64},
-    )
-    return x + length(model.quadratic_eq_constraints)
-end
-
-_eval_function(::Nothing, ::Any) = 0.0
-
-_eval_function(f, x) = MOI.Utilities.eval_variables(xi -> x[xi.value], f)
-
 ### Eval_F_CB
 
-function _eval_objective(model::Optimizer, x)
-    if model.nlp_data.has_objective
+function MOI.eval_objective(model::Optimizer, x)
+    # TODO(odow): FEASIBILITY_SENSE could produce confusing solver output if
+    # a nonzero objective is set.
+    if model.sense == MOI.FEASIBILITY_SENSE
+        return 0.0
+    elseif model.nlp_data.has_objective
         return MOI.eval_objective(model.nlp_data.evaluator, x)
     end
-    return _eval_function(model.objective, x)
+    return MOI.eval_objective(model.linear, x)
 end
 
 ### Eval_Grad_F_CB
 
-_fill_gradient(::Any, ::Any, ::Nothing) = nothing
-
-function _fill_gradient(grad, ::Vector, f::MOI.VariableIndex)
-    grad[f.value] = 1.0
-    return
-end
-
-function _fill_gradient(grad, ::Vector, f::MOI.ScalarAffineFunction{Float64})
-    for term in f.terms
-        grad[term.variable.value] += term.coefficient
-    end
-    return
-end
-
-function _fill_gradient(
-    grad,
-    x::Vector,
-    quad::MOI.ScalarQuadraticFunction{Float64},
-)
-    for term in quad.affine_terms
-        grad[term.variable.value] += term.coefficient
-    end
-    for term in quad.quadratic_terms
-        row_idx = term.variable_1
-        col_idx = term.variable_2
-        if row_idx == col_idx
-            grad[row_idx.value] += term.coefficient * x[row_idx.value]
-        else
-            grad[row_idx.value] += term.coefficient * x[col_idx.value]
-            grad[col_idx.value] += term.coefficient * x[row_idx.value]
-        end
-    end
-    return
-end
-
-function _eval_objective_gradient(model::Optimizer, grad, x)
-    if model.nlp_data.has_objective
+function MOI.eval_objective_gradient(model::Optimizer, grad, x)
+    if model.sense == MOI.FEASIBILITY_SENSE
+        grad .= zero(eltype(grad))
+    elseif model.nlp_data.has_objective
         MOI.eval_objective_gradient(model.nlp_data.evaluator, grad, x)
     else
-        fill!(grad, 0.0)
-        _fill_gradient(grad, x, model.objective)
+        MOI.eval_objective_gradient(model.linear, grad, x)
     end
     return
 end
 
 ### Eval_G_CB
 
-function _eval_constraint(model::Optimizer, g, x)
-    row = 1
-    for key in _CONSTRAINT_ORDERING
-        for info in getfield(model, key)
-            g[row] = _eval_function(info.func, x)
-            row += 1
-        end
-    end
-    nlp_g = view(g, row:length(g))
-    MOI.eval_constraint(model.nlp_data.evaluator, nlp_g, x)
+function MOI.eval_constraint(model::Optimizer, g, x)
+    MOI.eval_constraint(model.linear, g, x)
+    g_nlp = view(g, (length(model.linear)+1):length(g))
+    MOI.eval_constraint(model.nlp_data.evaluator, g_nlp, x)
     return
 end
 
 ### Eval_Jac_G_CB
 
-function _append_to_jacobian_sparsity(J, f::MOI.ScalarAffineFunction, row)
-    for term in f.terms
-        push!(J, (row, term.variable.value))
-    end
-    return
-end
-
-function _append_to_jacobian_sparsity(J, f::MOI.ScalarQuadraticFunction, row)
-    for term in f.affine_terms
-        push!(J, (row, term.variable.value))
-    end
-    for term in f.quadratic_terms
-        row_idx = term.variable_1
-        col_idx = term.variable_2
-        if row_idx == col_idx
-            push!(J, (row, row_idx.value))
-        else
-            push!(J, (row, row_idx.value))
-            push!(J, (row, col_idx.value))
-        end
-    end
-    return
-end
-
-function _jacobian_structure(model::Optimizer)
-    J = Tuple{Int64,Int64}[]
-    row = 1
-    for key in _CONSTRAINT_ORDERING
-        for info in getfield(model, key)
-            _append_to_jacobian_sparsity(J, info.func, row)
-            row += 1
-        end
-    end
+function MOI.jacobian_structure(model::Optimizer)
+    J = MOI.jacobian_structure(model.linear)
+    offset = length(model.linear)
     if length(model.nlp_data.constraint_bounds) > 0
-        for (nlp_row, col) in MOI.jacobian_structure(model.nlp_data.evaluator)
-            push!(J, (nlp_row + row - 1, col))
+        for (row, col) in MOI.jacobian_structure(model.nlp_data.evaluator)
+            push!(J, (row + offset, col))
         end
     end
     return J
 end
 
-function _fill_constraint_jacobian(
-    values,
-    offset,
-    ::Vector,
-    f::MOI.ScalarAffineFunction,
-)
-    num_coefficients = length(f.terms)
-    for i in 1:num_coefficients
-        values[offset+i] = f.terms[i].coefficient
-    end
-    return num_coefficients
-end
-
-function _fill_constraint_jacobian(
-    values,
-    offset,
-    x,
-    f::MOI.ScalarQuadraticFunction,
-)
-    nterms = 0
-    for term in f.affine_terms
-        nterms += 1
-        values[offset+nterms] = term.coefficient
-    end
-    for term in f.quadratic_terms
-        row_idx = term.variable_1
-        col_idx = term.variable_2
-        if row_idx == col_idx
-            nterms += 1
-            values[offset+nterms] = term.coefficient * x[col_idx.value]
-        else
-            # Note that the order matches the Jacobian sparsity pattern.
-            nterms += 2
-            values[offset+nterms-1] = term.coefficient * x[col_idx.value]
-            values[offset+nterms] = term.coefficient * x[row_idx.value]
-        end
-    end
-    return nterms
-end
-
-function _eval_constraint_jacobian(model::Optimizer, values, x)
-    offset = 0
-    for key in _CONSTRAINT_ORDERING
-        for info in getfield(model, key)
-            offset += _fill_constraint_jacobian(values, offset, x, info.func)
-        end
-    end
-    nlp_values = view(values, (1+offset):length(values))
+function MOI.eval_constraint_jacobian(model::Optimizer, values, x)
+    offset = MOI.eval_constraint_jacobian(model.linear, values, x)
+    nlp_values = view(values, (offset+1):length(values))
     MOI.eval_constraint_jacobian(model.nlp_data.evaluator, nlp_values, x)
     return
 end
 
 ### Eval_H_CB
 
-_append_to_hessian_sparsity(::Any, ::Any) = nothing
-
-function _append_to_hessian_sparsity(H, f::MOI.ScalarQuadraticFunction)
-    for term in f.quadratic_terms
-        push!(H, (term.variable_1.value, term.variable_2.value))
-    end
-    return
-end
-
-function _append_hessian_lagrangian_structure(H, model::Optimizer)
-    if !model.nlp_data.has_objective
-        _append_to_hessian_sparsity(H, model.objective)
-    end
-    for info in model.quadratic_le_constraints
-        _append_to_hessian_sparsity(H, info.func)
-    end
-    for info in model.quadratic_ge_constraints
-        _append_to_hessian_sparsity(H, info.func)
-    end
-    for info in model.quadratic_eq_constraints
-        _append_to_hessian_sparsity(H, info.func)
-    end
+function MOI.hessian_lagrangian_structure(model::Optimizer)
+    H = MOI.hessian_lagrangian_structure(model.linear)
     append!(H, MOI.hessian_lagrangian_structure(model.nlp_data.evaluator))
-    return
+    return H
 end
 
-_fill_hessian_lagrangian(::Any, ::Any, ::Any, ::Any) = 0
-
-function _fill_hessian_lagrangian(H, offset, λ, f::MOI.ScalarQuadraticFunction)
-    for term in f.quadratic_terms
-        H[offset+1] = λ * term.coefficient
-        offset += 1
-    end
-    return length(f.quadratic_terms)
-end
-
-function _eval_hessian_lagrangian(
-    ::Type{S},
-    model::Optimizer,
-    H,
-    μ,
-    offset,
-) where {S}
-    F = MOI.ScalarQuadraticFunction{Float64}
-    offset_start = _offset(model, F, S)
-    for (i, info) in enumerate(_constraints(model, F, S))
-        offset +=
-            _fill_hessian_lagrangian(H, offset, μ[offset_start+i], info.func)
-    end
-    return offset
-end
-
-function _eval_hessian_lagrangian(model::Optimizer, H, x, σ, μ)
-    offset = 0
-    if !model.nlp_data.has_objective
-        offset += _fill_hessian_lagrangian(H, 0, σ, model.objective)
-    end
-    # Handles any quadratic constraints that are present. The order matters.
-    offset =
-        _eval_hessian_lagrangian(MOI.LessThan{Float64}, model, H, μ, offset)
-    offset =
-        _eval_hessian_lagrangian(MOI.GreaterThan{Float64}, model, H, μ, offset)
-    offset = _eval_hessian_lagrangian(MOI.EqualTo{Float64}, model, H, μ, offset)
-    # Handles the Hessian in the nonlinear block
-    MOI.eval_hessian_lagrangian(
-        model.nlp_data.evaluator,
-        view(H, 1+offset:length(H)),
-        x,
-        σ,
-        view(μ, 1+_nlp_constraint_offset(model):length(μ)),
-    )
+function MOI.eval_hessian_lagrangian(model::Optimizer, H, x, σ, μ)
+    offset = MOI.eval_hessian_lagrangian(model.linear, H, x, σ, μ)
+    H_nlp = view(H, (offset+1):length(H))
+    μ_nlp = view(μ, (length(model.linear)+1):length(μ))
+    MOI.eval_hessian_lagrangian(model.nlp_data.evaluator, H_nlp, x, σ, μ_nlp)
     return
 end
 
 ### MOI.optimize!
 
-_bounds(s::MOI.LessThan) = (-Inf, s.upper)
-_bounds(s::MOI.GreaterThan) = (s.lower, Inf)
-_bounds(s::MOI.EqualTo) = (s.value, s.value)
-
 function MOI.optimize!(model::Optimizer)
-    # TODO: Reuse model.inner for incremental solves if possible.
-    num_quadratic_constraints =
-        length(model.quadratic_le_constraints) +
-        length(model.quadratic_ge_constraints) +
-        length(model.quadratic_eq_constraints)
+    num_quadratic_constraints = length(model.linear.hessian_structure) > 0
     num_nlp_constraints = length(model.nlp_data.constraint_bounds)
     has_hessian = :Hess in MOI.features_available(model.nlp_data.evaluator)
     init_feat = [:Grad]
@@ -1102,35 +567,23 @@ function MOI.optimize!(model::Optimizer)
         MOI.initialize(model.nlp_data.evaluator, init_feat)
         model.nlp_data_needs_initialize = false
     end
-    jacobian_sparsity = _jacobian_structure(model)
-    hessian_sparsity = Tuple{Int,Int}[]
-    if has_hessian
-        _append_hessian_lagrangian_structure(hessian_sparsity, model)
+    jacobian_sparsity = MOI.jacobian_structure(model)
+    hessian_sparsity = if has_hessian
+        MOI.hessian_lagrangian_structure(model)
+    else
+        Tuple{Int,Int}[]
     end
-    function eval_f_cb(x)
-        # TODO(odow): FEASIBILITY_SENSE could produce confusing solver output if
-        # a nonzero objective is set.
-        if model.sense == MOI.FEASIBILITY_SENSE
-            return 0.0
-        end
-        return _eval_objective(model, x)
-    end
-    function eval_grad_f_cb(x, grad_f)
-        if model.sense == MOI.FEASIBILITY_SENSE
-            grad_f .= zero(eltype(grad_f))
-        else
-            _eval_objective_gradient(model, grad_f, x)
-        end
-        return
-    end
-    eval_g_cb(x, g) = _eval_constraint(model, g, x)
+
+    eval_f_cb(x) = MOI.eval_objective(model, x)
+    eval_grad_f_cb(x, grad_f) = MOI.eval_objective_gradient(model, grad_f, x)
+    eval_g_cb(x, g) = MOI.eval_constraint(model, g, x)
     function eval_jac_g_cb(x, rows, cols, values)
         if values === nothing
             for i in 1:length(jacobian_sparsity)
                 rows[i], cols[i] = jacobian_sparsity[i]
             end
         else
-            _eval_constraint_jacobian(model, values, x)
+            MOI.eval_constraint_jacobian(model, values, x)
         end
         return
     end
@@ -1140,18 +593,11 @@ function MOI.optimize!(model::Optimizer)
                 rows[i], cols[i] = hessian_sparsity[i]
             end
         else
-            _eval_hessian_lagrangian(model, values, x, obj_factor, lambda)
+            MOI.eval_hessian_lagrangian(model, values, x, obj_factor, lambda)
         end
         return
     end
-    g_L, g_U = Float64[], Float64[]
-    for key in _CONSTRAINT_ORDERING
-        for info in getfield(model, key)
-            l, u = _bounds(info.set)
-            push!(g_L, l)
-            push!(g_U, u)
-        end
-    end
+    g_L, g_U = copy(model.linear.g_L), copy(model.linear.g_U)
     for bound in model.nlp_data.constraint_bounds
         push!(g_L, bound.lower)
         push!(g_U, bound.upper)
@@ -1222,43 +668,34 @@ function MOI.optimize!(model::Optimizer)
     end
     # Initialize the starting point, projecting variables from 0 onto their
     # bounds if VariablePrimalStart  is not provided.
-    for (i, v) in enumerate(model.variable_primal_start)
-        if v !== nothing
-            model.inner.x[i] = v
+    for i in 1:length(model.variable_primal_start)
+        model.inner.x[i] = if model.variable_primal_start[i] !== nothing
+            model.variable_primal_start[i]
         else
-            model.inner.x[i] = max(0.0, model.variables.lower[i])
-            model.inner.x[i] = min(model.inner.x[i], model.variables.upper[i])
+            clamp(0.0, model.variables.lower[i], model.variables.upper[i])
         end
     end
-    # Initialize the dual start to 0.0 if NLPBlockDualStart is not provided.
     if model.nlp_dual_start === nothing
+        # Initialize the dual start to 0.0 if NLPBlockDualStart is not provided.
         model.nlp_dual_start = zeros(Float64, num_nlp_constraints)
     end
-    # ConstraintDualStart
-    row = 1
-    for key in _CONSTRAINT_ORDERING
-        for info in getfield(model, key)
-            model.inner.mult_g[row] = _dual_start(model, info.dual_start, -1)
-            row += 1
-        end
-    end
-    for dual_start in model.nlp_dual_start
-        model.inner.mult_g[row] = _dual_start(model, dual_start, -1)
+    row = 0
+    for start in model.linear.mult_g
         row += 1
+        model.inner.mult_g[row] = _dual_start(model, start, -1)
     end
-    # ConstraintDualStart for variable bounds
+    for start in model.nlp_dual_start
+        row += 1
+        model.inner.mult_g[row] = _dual_start(model, start, -1)
+    end
     for i in 1:length(model.inner.n)
-        model.inner.mult_x_L[i] =
-            _dual_start(model, model.variable_lower_start[i])
-        model.inner.mult_x_U[i] =
-            _dual_start(model, model.variable_upper_start[i], -1)
+        model.inner.mult_x_L[i] = _dual_start(model, model.mult_x_L[i])
+        model.inner.mult_x_U[i] = _dual_start(model, model.mult_x_U[i], -1)
     end
-    # Initialize CallbackFunction.
     if model.callback !== nothing
         SetIntermediateCallback(model.inner, model.callback)
     end
     IpoptSolve(model.inner)
-    # Store SolveTimeSec.
     model.solve_time = time() - start_time
     return
 end
@@ -1425,30 +862,17 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintPrimal,
-    ci::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
+    ci::MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS},
+)
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
-    return model.inner.g[_offset(model, F, S)+ci.value]
+    return model.inner.g[ci.value]
 end
 
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintPrimal,
-    ci::MOI.ConstraintIndex{
-        MOI.VariableIndex,
-        <:Union{
-            MOI.LessThan{Float64},
-            MOI.GreaterThan{Float64},
-            MOI.EqualTo{Float64},
-        },
-    },
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,<:_SETS},
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
@@ -1462,18 +886,12 @@ _dual_multiplier(model::Optimizer) = model.sense == MOI.MIN_SENSE ? 1.0 : -1.0
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintDual,
-    ci::MOI.ConstraintIndex{F,S},
-) where {
-    F<:Union{
-        MOI.ScalarAffineFunction{Float64},
-        MOI.ScalarQuadraticFunction{Float64},
-    },
-    S,
-}
+    ci::MOI.ConstraintIndex{<:_FUNCTIONS,<:_SETS},
+)
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
     s = -_dual_multiplier(model)
-    return s * model.inner.mult_g[_offset(model, F, S)+ci.value]
+    return s * model.inner.mult_g[ci.value]
 end
 
 function MOI.get(
@@ -1514,7 +932,7 @@ end
 function MOI.get(model::Optimizer, attr::MOI.NLPBlockDual)
     MOI.check_result_index_bounds(model, attr)
     s = -_dual_multiplier(model)
-    return s .* model.inner.mult_g[(1+_nlp_constraint_offset(model)):end]
+    return s .* model.inner.mult_g[(length(model.linear)+1):end]
 end
 
 ### Ipopt.CallbackFunction

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,496 @@
+# Copyright (c) 2013: Iain Dunning, Miles Lubin, and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+@enum(
+    FunctionType,
+    kFunctionTypeVariableIndex,
+    kFunctionTypeScalarAffine,
+    kFunctionTypeScalarQuadratic,
+)
+
+@enum(BoundType, kBoundTypeLessThan, kBoundTypeGreaterThan, kBoundTypeEqualTo,)
+
+mutable struct LinearQuadraticConstraintBlock{T}
+    objective_type::FunctionType
+    objective_constant::T
+    objective_linear_columns::Vector{Int}
+    objective_linear_coefficients::Vector{T}
+    objective_hessian_structure::Vector{Tuple{Int,Int}}
+    objective_hessian_coefficients::Vector{T}
+
+    linear_row_ends::Vector{Int}
+    linear_jacobian_structure::Vector{Tuple{Int,Int}}
+    linear_coefficients::Vector{T}
+
+    quadratic_row_ends::Vector{Int}
+    hessian_structure::Vector{Tuple{Int,Int}}
+    quadratic_coefficients::Vector{T}
+
+    g_L::Vector{T}
+    g_U::Vector{T}
+    mult_g::Vector{Union{Nothing,T}}
+    function_type::Vector{FunctionType}
+    bound_type::Vector{BoundType}
+
+    function LinearQuadraticConstraintBlock{T}() where {T}
+        return new(
+            # Objective coefficients
+            kFunctionTypeScalarAffine,
+            zero(T),
+            Int[],
+            T[],
+            Tuple{Int,Int}[],
+            T[],
+            # Linear constraints
+            Int[],
+            Tuple{Int,Int}[],
+            T[],
+            # Affine constraints
+            Int[],
+            Tuple{Int,Int}[],
+            T[],
+            # Bounds
+            T[],
+            T[],
+            T[],
+            FunctionType[],
+            BoundType[],
+        )
+    end
+end
+
+Base.length(block::LinearQuadraticConstraintBlock) = length(block.bound_type)
+
+function _set_objective(
+    block::LinearQuadraticConstraintBlock{T},
+    f::MOI.VariableIndex,
+) where {T}
+    push!(block.objective_linear_columns, f.value)
+    push!(block.objective_linear_coefficients, one(T))
+    return zero(T)
+end
+
+function _set_objective(
+    block::LinearQuadraticConstraintBlock{T},
+    f::MOI.ScalarAffineFunction{T},
+) where {T}
+    _set_objective(block, f.terms)
+    return f.constant
+end
+
+function _set_objective(
+    block::LinearQuadraticConstraintBlock{T},
+    f::MOI.ScalarQuadraticFunction{T},
+) where {T}
+    _set_objective(block, f.affine_terms)
+    for term in f.quadratic_terms
+        i, j = term.variable_1.value, term.variable_2.value
+        push!(block.objective_hessian_structure, (i, j))
+        push!(block.objective_hessian_coefficients, term.coefficient)
+    end
+    return f.constant
+end
+
+function _set_objective(
+    block::LinearQuadraticConstraintBlock{T},
+    terms::Vector{MOI.ScalarAffineTerm{T}},
+) where {T}
+    for term in terms
+        push!(block.objective_linear_columns, term.variable.value)
+        push!(block.objective_linear_coefficients, term.coefficient)
+    end
+    return
+end
+
+function MOI.set(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ObjectiveFunction{F},
+    func::F,
+) where {
+    T,
+    F<:Union{
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+    },
+}
+    empty!(block.objective_hessian_structure)
+    empty!(block.objective_hessian_coefficients)
+    empty!(block.objective_linear_columns)
+    empty!(block.objective_linear_coefficients)
+    block.objective_constant = _set_objective(block, func)
+    block.objective_type = _function_info(func)
+    return
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ObjectiveFunctionType,
+) where {T}
+    return _function_type_to_set(T, block.objective_type)
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ObjectiveFunction{F},
+) where {T,F}
+    affine_terms = MOI.ScalarAffineTerm{T}[
+        MOI.ScalarAffineTerm(
+            block.objective_linear_coefficients[i],
+            MOI.VariableIndex(x),
+        ) for (i, x) in enumerate(block.objective_linear_columns)
+    ]
+    quadratic_terms = MOI.ScalarQuadraticTerm{T}[]
+    for (i, coef) in enumerate(block.objective_hessian_coefficients)
+        r, c = block.objective_hessian_structure[i]
+        push!(
+            quadratic_terms,
+            MOI.ScalarQuadraticTerm(
+                coef,
+                MOI.VariableIndex(r),
+                MOI.VariableIndex(c),
+            ),
+        )
+    end
+    obj = MOI.ScalarQuadraticFunction(
+        quadratic_terms,
+        affine_terms,
+        block.objective_constant,
+    )
+    return convert(F, obj)
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ListOfConstraintTypesPresent,
+) where {T}
+    constraints = Set{Tuple{Type,Type}}()
+    for i in 1:length(block)
+        F = _function_type_to_set(T, block.function_type[i])
+        S = _bound_type_to_set(T, block.bound_type[i])
+        push!(constraints, (F, S))
+    end
+    return collect(constraints)
+end
+
+function MOI.is_valid(
+    block::LinearQuadraticConstraintBlock{T},
+    ci::MOI.ConstraintIndex{F,S},
+) where {
+    T,
+    F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
+    S<:Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
+}
+    return 1 <= ci.value <= length(block)
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ListOfConstraintIndices{F,S},
+) where {
+    T,
+    F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
+    S<:Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
+}
+    ret = MOI.ConstraintIndex{F,S}[]
+    for i in 1:length(block)
+        if _bound_type_to_set(T, block.bound_type[i]) != S
+            continue
+        elseif _function_type_to_set(T, block.function_type[i]) != F
+            continue
+        end
+        push!(ret, MOI.ConstraintIndex{F,S}(i))
+    end
+    return ret
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.NumberOfConstraints{F,S},
+) where {
+    T,
+    F<:Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
+    S<:Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
+}
+    return length(MOI.get(block, MOI.ListOfConstraintIndices{F,S}()))
+end
+
+function _bound_type_to_set(::Type{T}, k::BoundType) where {T}
+    if k == kBoundTypeEqualTo
+        return MOI.EqualTo{T}
+    elseif k == kBoundTypeLessThan
+        return MOI.LessThan{T}
+    else
+        @assert k == kBoundTypeGreaterThan
+        return MOI.GreaterThan{T}
+    end
+end
+
+function _function_type_to_set(::Type{T}, k::FunctionType) where {T}
+    if k == kFunctionTypeVariableIndex
+        return MOI.VariableIndex
+    elseif k == kFunctionTypeScalarAffine
+        return MOI.ScalarAffineFunction{T}
+    else
+        @assert k == kFunctionTypeScalarQuadratic
+        return MOI.ScalarQuadraticFunction{T}
+    end
+end
+
+_function_info(::MOI.VariableIndex) = kFunctionTypeVariableIndex
+_function_info(::MOI.ScalarAffineFunction) = kFunctionTypeScalarAffine
+_function_info(::MOI.ScalarQuadraticFunction) = kFunctionTypeScalarQuadratic
+
+_set_info(s::MOI.LessThan) = kBoundTypeLessThan, -Inf, s.upper
+_set_info(s::MOI.GreaterThan) = kBoundTypeGreaterThan, s.lower, Inf
+_set_info(s::MOI.EqualTo) = kBoundTypeEqualTo, s.value, s.value
+_set_info(s::MOI.Interval) = kBoundTypeInterval, s.lower, s.upper
+
+function _add_function(
+    block::LinearQuadraticConstraintBlock{T},
+    f::MOI.ScalarAffineFunction{T},
+) where {T}
+    _add_function(block, f.terms)
+    push!(block.quadratic_row_ends, length(block.quadratic_coefficients))
+    return kFunctionTypeScalarAffine, f.constant
+end
+
+function _add_function(
+    block::LinearQuadraticConstraintBlock{T},
+    f::MOI.ScalarQuadraticFunction{T},
+) where {T}
+    _add_function(block, f.affine_terms)
+    for term in f.quadratic_terms
+        i, j = term.variable_1.value, term.variable_2.value
+        push!(block.hessian_structure, (i, j))
+        push!(block.quadratic_coefficients, term.coefficient)
+    end
+    push!(block.quadratic_row_ends, length(block.quadratic_coefficients))
+    return kFunctionTypeScalarQuadratic, f.constant
+end
+
+function _add_function(
+    block::LinearQuadraticConstraintBlock{T},
+    terms::Vector{MOI.ScalarAffineTerm{T}},
+) where {T}
+    row = length(block) + 1
+    for term in terms
+        push!(block.linear_jacobian_structure, (row, term.variable.value))
+        push!(block.linear_coefficients, term.coefficient)
+    end
+    push!(block.linear_row_ends, length(block.linear_jacobian_structure))
+    return
+end
+
+function MOI.add_constraint(
+    block::LinearQuadraticConstraintBlock{T},
+    f::Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}},
+    set::Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
+) where {T}
+    function_type, constant = _add_function(block, f)
+    bound_type, l, u = _set_info(set)
+    push!(block.g_L, l - constant)
+    push!(block.g_U, u - constant)
+    push!(block.mult_g, nothing)
+    push!(block.bound_type, bound_type)
+    push!(block.function_type, function_type)
+    return MOI.ConstraintIndex{typeof(f),typeof(set)}(length(block.bound_type))
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ConstraintFunction,
+    c::MOI.ConstraintIndex{F,S},
+) where {T,F,S}
+    offset = row == 1 ? 1 : block.linear_row_ends[row-1]
+    affine_terms = MOI.ScalarAffineTerm{T}[
+        MOI.ScalarAffineTerm(
+            block.linear_coefficients[i],
+            MOI.VariableIndex(block.linear_jacobian_structure[i][2]),
+        ) for i in offset:block.linear_row_ends[row]
+    ]
+    quadratic_terms = MOI.ScalarQuadraticTerm{T}[]
+    offset = row == 1 ? 1 : block.linear_row_ends[row-1]
+    for i in offset:block.quadratic_row_ends[row]
+        r, c = block.hessian_structure[i]
+        push!(
+            quadratic_terms,
+            MOI.ScalarQuadraticTerm(
+                block.quadratic_coefficients[i],
+                MOI.VariableIndex(r),
+                MOI.VariableIndex(c),
+            ),
+        )
+    end
+    if length(quadratic_terms) == 0
+        return MOI.ScalarAffineFunction(affine_terms, zero(T))
+    end
+    return MOI.ScalarQuadraticFunction(quadratic_terms, affine_terms, zero(T))
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ConstraintSet,
+    c::MOI.ConstraintIndex{F,S},
+) where {T,F,S}
+    row = c.value
+    if block.bound_type[row] == kBoundTypeEqualTo
+        return MOI.EqualTo(block.g_L[row])
+    elseif block.bound_type[row] == kBoundTypeLessThan
+        return MOI.LessThan(block.g_U[row])
+    else
+        @assert block.bound_type[row] == kBoundTypeGreaterThan
+        return MOI.GreaterThan(block.g_L[row])
+    end
+end
+
+function MOI.get(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ConstraintDualStart,
+    c::MOI.ConstraintIndex{F,S},
+) where {T,F,S}
+    return block.mult_g[c.value]
+end
+
+function MOI.set(
+    block::LinearQuadraticConstraintBlock{T},
+    ::MOI.ConstraintDualStart,
+    c::MOI.ConstraintIndex{F,S},
+    value,
+) where {T,F,S}
+    block.mult_g[c.value] = value
+    return
+end
+
+function MOI.eval_objective(
+    block::LinearQuadraticConstraintBlock{T},
+    x::AbstractVector{T},
+) where {T}
+    y = block.objective_constant
+    for (i, c) in enumerate(block.objective_linear_columns)
+        y += block.objective_linear_coefficients[i] * x[c]
+    end
+    for (i, (r, c)) in enumerate(block.objective_hessian_structure)
+        if r == c
+            y += block.objective_hessian_coefficients[i] * x[r] * x[c] / 2
+        else
+            y += block.objective_hessian_coefficients[i] * x[r] * x[c]
+        end
+    end
+    return y
+end
+
+function MOI.eval_objective_gradient(
+    block::LinearQuadraticConstraintBlock{T},
+    g::AbstractVector{T},
+    x::AbstractVector{T},
+) where {T}
+    g .= zero(T)
+    for (i, c) in enumerate(block.objective_linear_columns)
+        g[c] += block.objective_linear_coefficients[i]
+    end
+    for (i, (r, c)) in enumerate(block.objective_hessian_structure)
+        g[r] += block.objective_hessian_coefficients[i] * x[c]
+        if r != c
+            g[c] += block.objective_hessian_coefficients[i] * x[r]
+        end
+    end
+    return
+end
+
+function MOI.eval_constraint(
+    block::LinearQuadraticConstraintBlock{T},
+    g::AbstractVector{T},
+    x::AbstractVector{T},
+) where {T}
+    for i in 1:length(g)
+        g[i] = zero(T)
+    end
+    for (i, (r, c)) in enumerate(block.linear_jacobian_structure)
+        g[r] += block.linear_coefficients[i] * x[c]
+    end
+    i = 0
+    for row in 1:length(block.quadratic_row_ends)
+        while i < block.quadratic_row_ends[row]
+            i += 1
+            r, c = block.hessian_structure[i]
+            if r == c
+                g[row] += block.quadratic_coefficients[i] * x[r] * x[c] / 2
+            else
+                g[row] += block.quadratic_coefficients[i] * x[r] * x[c]
+            end
+        end
+    end
+    return
+end
+
+function MOI.jacobian_structure(block::LinearQuadraticConstraintBlock)
+    J = copy(block.linear_jacobian_structure)
+    i = 0
+    for row in 1:length(block.quadratic_row_ends)
+        while i < block.quadratic_row_ends[row]
+            i += 1
+            r, c = block.hessian_structure[i]
+            push!(J, (row, r))
+            if r != c
+                push!(J, (row, c))
+            end
+        end
+    end
+    return J
+end
+
+function MOI.eval_constraint_jacobian(
+    block::LinearQuadraticConstraintBlock{T},
+    J::AbstractVector{T},
+    x::AbstractVector{T},
+) where {T}
+    nterms = 0
+    for coef in block.linear_coefficients
+        nterms += 1
+        J[nterms] = coef
+    end
+    i = 0
+    for row in 1:length(block.quadratic_row_ends)
+        while i < block.quadratic_row_ends[row]
+            i += 1
+            r, c = block.hessian_structure[i]
+            nterms += 1
+            J[nterms] = block.quadratic_coefficients[i] * x[c]
+            if r != c
+                nterms += 1
+                J[nterms] = block.quadratic_coefficients[i] * x[r]
+            end
+        end
+    end
+    return nterms
+end
+
+function MOI.hessian_lagrangian_structure(block::LinearQuadraticConstraintBlock)
+    return vcat(block.objective_hessian_structure, block.hessian_structure)
+end
+
+function MOI.eval_hessian_lagrangian(
+    block::LinearQuadraticConstraintBlock{T},
+    H::AbstractVector{T},
+    ::AbstractVector{T},
+    σ::T,
+    μ::AbstractVector{T},
+) where {T}
+    nterms = 0
+    for c in block.objective_hessian_coefficients
+        nterms += 1
+        H[nterms] = σ * c
+    end
+    i = 0
+    for row in 1:length(block.quadratic_row_ends)
+        while i < block.quadratic_row_ends[row]
+            i += 1
+            nterms += 1
+            H[nterms] = μ[row] * block.quadratic_coefficients[i]
+        end
+    end
+    return nterms
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -242,7 +242,6 @@ _function_info(::MOI.ScalarQuadraticFunction) = _kFunctionTypeScalarQuadratic
 _set_info(s::MOI.LessThan) = _kBoundTypeLessThan, -Inf, s.upper
 _set_info(s::MOI.GreaterThan) = _kBoundTypeGreaterThan, s.lower, Inf
 _set_info(s::MOI.EqualTo) = _kBoundTypeEqualTo, s.value, s.value
-_set_info(s::MOI.Interval) = _kBoundTypeInterval, s.lower, s.upper
 
 function _add_function(
     block::QPBlockData{T},

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -300,7 +300,8 @@ function MOI.get(
     ::MOI.ConstraintFunction,
     c::MOI.ConstraintIndex{F,S},
 ) where {T,F,S}
-    offset = row == 1 ? 1 : block.linear_row_ends[row-1]
+    row = c.value
+    offset = row == 1 ? 1 : (block.linear_row_ends[row-1] + 1)
     affine_terms = MOI.ScalarAffineTerm{T}[
         MOI.ScalarAffineTerm(
             block.linear_coefficients[i],
@@ -308,7 +309,7 @@ function MOI.get(
         ) for i in offset:block.linear_row_ends[row]
     ]
     quadratic_terms = MOI.ScalarQuadraticTerm{T}[]
-    offset = row == 1 ? 1 : block.linear_row_ends[row-1]
+    offset = row == 1 ? 1 : (block.quadratic_row_ends[row-1] + 1)
     for i in offset:block.quadratic_row_ends[row]
         r, c = block.hessian_structure[i]
         push!(

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -277,7 +277,7 @@ function test_get_model()
         f_model = MOI.get(model, MOI.ConstraintFunction(), cis[1])
         s_model = MOI.get(model, MOI.ConstraintSet(), cis[1])
         cis = MOI.get(ipopt, MOI.ListOfConstraintIndices{F,S}())
-        @test length(cis) == 1
+        @test length(cis) == MOI.get(ipopt, MOI.NumberOfConstraints{F,S}()) == 1
         f_ipopt = MOI.get(ipopt, MOI.ConstraintFunction(), cis[1])
         s_ipopt = MOI.get(ipopt, MOI.ConstraintSet(), cis[1])
         @test s_model == s_ipopt


### PR DESCRIPTION
I started looking at how we can make in-place resolves of Ipopt fast, but it got tricky because the linear/quadratic components are messy. 

At some point, we can refactor the `utils.jl` file into MOI to solve: https://github.com/jump-dev/MathOptInterface.jl/issues/1397