### PR TITLE
Ipopt_jll with LBT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           - version: '1.6'
             os: ubuntu-latest
             arch: x86
+          - version: '1'
+            os: windows-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 [compat]
 Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
-OpenBLAS32_jll = "0.3.10"
+OpenBLAS32_jll = "=0.3.20"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 [compat]
 Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
+OpenBLAS32_jll = "0.3.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 [compat]
 Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
-OpenBLAS32_jll = "=0.3.20"
+OpenBLAS32_jll = "0.3.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 [compat]
 Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
-OpenBLAS32_jll = "0.3.10"
+OpenBLAS32_jll = "=0.3.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 [compat]
 Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
-OpenBLAS32_jll = "=0.3.10"
+OpenBLAS32_jll = "0.3.10"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "1.0.4"
 
 [deps]
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400"
+Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
 MathOptInterface = "1"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.401"
+Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.402"
 MathOptInterface = "1"
 OpenBLAS32_jll = "0.3.10"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.402"
+Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.403"
 MathOptInterface = "1"
 OpenBLAS32_jll = "0.3.10"
 julia = "1.6"

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -14,7 +14,10 @@ const MOI = MathOptInterface
 
 function __init__()
     if VERSION >= v"1.8"
-        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path; verbose = true)
+        LinearAlgebra.BLAS.lbt_forward(
+            OpenBLAS32_jll.libopenblas_path;
+            verbose = true,
+        )
     end
     global libipopt = Ipopt_jll.libipopt
     return

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -6,11 +6,14 @@
 module Ipopt
 
 import Ipopt_jll
+import OpenBLAS32_jll
 import MathOptInterface
+import LinearAlgebra
 
 const MOI = MathOptInterface
 
 function __init__()
+    (VERSION ≥ v"1.8") && LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
     global libipopt = Ipopt_jll.libipopt
     return
 end

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -13,7 +13,9 @@ import LinearAlgebra
 const MOI = MathOptInterface
 
 function __init__()
-    (VERSION ≥ v"1.8") && LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+    if VERSION >= v"1.8"
+        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+    end
     global libipopt = Ipopt_jll.libipopt
     return
 end

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -14,7 +14,7 @@ const MOI = MathOptInterface
 
 function __init__()
     if VERSION >= v"1.8"
-        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
+        LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path; verbose = true)
     end
     global libipopt = Ipopt_jll.libipopt
     return

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -13,7 +13,7 @@ import OpenBLAS32_jll
 const MOI = MathOptInterface
 
 function __init__()
-    if VERSION >= v"1.8"
+    if false # VERSION >= v"1.8"
         config = LinearAlgebra.BLAS.lbt_get_config()
         if !any(lib -> lib.interface == :lp64, config.loaded_libs)
             LinearAlgebra.BLAS.lbt_forward(

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -13,12 +13,13 @@ import OpenBLAS32_jll
 const MOI = MathOptInterface
 
 function __init__()
-    if false # VERSION >= v"1.8"
+    if VERSION >= v"1.8"
         config = LinearAlgebra.BLAS.lbt_get_config()
         if !any(lib -> lib.interface == :lp64, config.loaded_libs)
             LinearAlgebra.BLAS.lbt_forward(
                 OpenBLAS32_jll.libopenblas_path;
                 verbose = true,
+                clear = false,
             )
         end
     end

--- a/src/Ipopt.jl
+++ b/src/Ipopt.jl
@@ -6,18 +6,21 @@
 module Ipopt
 
 import Ipopt_jll
-import OpenBLAS32_jll
-import MathOptInterface
 import LinearAlgebra
+import MathOptInterface
+import OpenBLAS32_jll
 
 const MOI = MathOptInterface
 
 function __init__()
     if VERSION >= v"1.8"
-        LinearAlgebra.BLAS.lbt_forward(
-            OpenBLAS32_jll.libopenblas_path;
-            verbose = true,
-        )
+        config = LinearAlgebra.BLAS.lbt_get_config()
+        if !any(lib -> lib.interface == :lp64, config.loaded_libs)
+            LinearAlgebra.BLAS.lbt_forward(
+                OpenBLAS32_jll.libopenblas_path;
+                verbose = true,
+            )
+        end
     end
     global libipopt = Ipopt_jll.libipopt
     return

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -211,7 +211,7 @@ function test_hs071()
     finalize(prob) # Needed before the `rm` on Windows.
     # unlink the output file
     rm("blah.txt")
-   return
+    return
 end
 
 end  # TestCWrapper

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -3,12 +3,12 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-module TestCWrapper
+# module TestCWrapper
 
 using Ipopt
 using Test
 
-function test_hs071()
+# function test_hs071()
     # hs071
     # min x1 * x4 * (x1 + x2 + x3) + x3
     # st  x1 * x2 * x3 * x4 >= 25
@@ -211,9 +211,9 @@ function test_hs071()
     finalize(prob) # Needed before the `rm` on Windows.
     # unlink the output file
     rm("blah.txt")
-    return
-end
+#    return
+# end
 
-end  # TestCWrapper
+# end  # TestCWrapper
 
-runtests(TestCWrapper)
+# runtests(TestCWrapper)

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -3,12 +3,12 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-# module TestCWrapper
+module TestCWrapper
 
 using Ipopt
 using Test
 
-# function test_hs071()
+function test_hs071()
     # hs071
     # min x1 * x4 * (x1 + x2 + x3) + x3
     # st  x1 * x2 * x3 * x4 >= 25
@@ -211,9 +211,9 @@ using Test
     finalize(prob) # Needed before the `rm` on Windows.
     # unlink the output file
     rm("blah.txt")
-#    return
-# end
+   return
+end
 
-# end  # TestCWrapper
+end  # TestCWrapper
 
-# runtests(TestCWrapper)
+runtests(TestCWrapper)


### PR DESCRIPTION
close #6 

I updated and recompiled `MUMPS_seq_jll` / `Ipopt_jll` with [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline).
We can easily switch the BLAS backend now with the version `300.1400.401` of `Ipopt_jll`.
```
import LinearAlgebra, OpenBLAS32_jll
LinearAlgebra.BLAS.lbt_forward(OpenBLAS32_jll.libopenblas_path)
```
or
```
import LinearAlgebra, MKL_jll
LinearAlgebra.BLAS.lbt_forward(MKL_jll.libmkl_rt_path)
```
Because `Ipopt_jll` and `MUMPS_seq_jll` are compiled with `LBT_jll` now, we must add OpenBLAS32_jll as dependency here to have a least one 32 bit BLAS/LAPACK backend.

