### PR TITLE
add functionality to set constraint RHS

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -292,6 +292,17 @@ function MOI.get(
     return MOI.get(model.qp_data, attr, c)
 end
 
+function MOI.set(
+    model::Optimizer,
+    ::MOI.ConstraintSet,
+    ci::MOI.ConstraintIndex{F,S},
+    set::S,
+) where {F<:_FUNCTIONS,S<:_SETS}
+    MOI.set(model.qp_data, MOI.ConstraintSet(), ci, set)
+    model.inner = nothing
+    return
+end
+
 function MOI.supports(
     ::Optimizer,
     ::MOI.ConstraintDualStart,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -357,7 +357,7 @@ function MOI.set(
 ) where {T,F}
     row = c.value
     block.g_U[row] = set.upper
-    return nothing
+    return
 end
 
 function MOI.set(
@@ -368,7 +368,7 @@ function MOI.set(
 ) where {T,F}
     row = c.value
     block.g_L[row] = set.lower
-    return nothing
+    return
 end
 
 function MOI.set(
@@ -380,7 +380,7 @@ function MOI.set(
     row = c.value
     block.g_L[row] = set.value
     block.g_U[row] = set.value
-    return nothing
+    return
 end
 
 function MOI.get(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -349,6 +349,40 @@ function MOI.get(
     end
 end
 
+function MOI.set(
+    block::QPBlockData{T},
+    ::MOI.ConstraintSet,
+    c::MOI.ConstraintIndex{F,MOI.LessThan{T}},
+    set::MOI.LessThan{T},
+) where {T,F}
+    row = c.value
+    block.g_U[row] = set.upper
+    return nothing
+end
+
+function MOI.set(
+    block::QPBlockData{T},
+    ::MOI.ConstraintSet,
+    c::MOI.ConstraintIndex{F,MOI.GreaterThan{T}},
+    set::MOI.GreaterThan{T},
+) where {T,F}
+    row = c.value
+    block.g_L[row] = set.lower
+    return nothing
+end
+
+function MOI.set(
+    block::QPBlockData{T},
+    ::MOI.ConstraintSet,
+    c::MOI.ConstraintIndex{F,MOI.EqualTo{T}},
+    set::MOI.EqualTo{T},
+) where {T,F}
+    row = c.value
+    block.g_L[row] = set.value
+    block.g_U[row] = set.value
+    return nothing
+end
+
 function MOI.get(
     block::QPBlockData{T},
     ::MOI.ConstraintDualStart,


### PR DESCRIPTION
`MOI.set( model::Optimizer, ::MOI.ConstraintSet, ci::MOI.ConstraintIndex{F,S}, set::S ) where {F<:_FUNCTIONS,S<:_SETS}` seems to be missing. 
I'm not sure if this is a really dumb PR because Ipopt does not truly support it, but on a few examples it seems to work as intended. 
The following script demonstrates what should be accomplished: 
```julia
using MathOptInterface, Ipopt
MOIU = MathOptInterface.Utilities 
MOI = MathOptInterface

model = MOIU.CachingOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()), MOIU.AUTOMATIC)
varidxs = MOI.add_variables(model, 2)
MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([5.0, -2.0], [varidxs[1], varidxs[2]]), 1.0),)
MOI.set(model, MOI.ObjectiveSense(),MOI.MIN_SENSE)
ctridx_vbound1 = MOI.add_constraint(model, varidxs[1], MOI.GreaterThan(0.0))
ctridx_vbound2 = MOI.add_constraint(model, varidxs[2], MOI.GreaterThan(0.0))
ctridx_eq = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, varidxs), 0.0), MOI.EqualTo(6.0))
ctridx_g = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, varidxs), 0.0), MOI.GreaterThan(2.0))
ctridx_l = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, varidxs), 0.0), MOI.LessThan(10.0))

solver = MOI.instantiate(Ipopt.Optimizer; with_bridge_type=Float64)
idxmap = MOI.copy_to(solver,model)

@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_eq]) == MOI.EqualTo(6.0)
MOI.set(solver, MOI.ConstraintSet(), ctridx_eq, MOI.EqualTo(5.0))
@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_eq]) == MOI.EqualTo(5.0)

@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_l]) == MOI.LessThan(10.0)
MOI.set(solver, MOI.ConstraintSet(), idxmap[ctridx_l], MOI.LessThan(9.0))
@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_l]) == MOI.LessThan(9.0)

@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_g]) == MOI.GreaterThan(2.0)
MOI.set(solver, MOI.ConstraintSet(), idxmap[ctridx_g], MOI.GreaterThan(1.0))
@assert MOI.get(solver, MOI.ConstraintSet(), idxmap[ctridx_g]) == MOI.GreaterThan(1.0)

MOI.optimize!(solver)

@assert isapprox(MOI.get(solver, MOI.VariablePrimal(), idxmap[varidxs[1]]), 0; atol=1e-8) 
@assert isapprox(MOI.get(solver, MOI.VariablePrimal(), idxmap[varidxs[2]]), 5; atol=1e-8)
```
I'm not experienced at all in these matters, so I'm really sorry if this is a bad idea...

PS: Also not sure if I made any formal/procedural mistakes by directly making this a PR as well as in the process, so I would be happy about a small notice in case I did. Once again, I'm very inexperienced in this and did not mean to disturb anything :D