### PR TITLE
Change cpu_time to wall_time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 
 [compat]
-Ipopt_jll = "=3.13.2, =3.13.4, =300.1400.400, =300.1400.403"
+Ipopt_jll = "=300.1400.400, =300.1400.403"
 MathOptInterface = "1"
 OpenBLAS32_jll = "0.3.10"
 julia = "1.6"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -149,17 +149,17 @@ MOI.get(model::Optimizer, ::MOI.Silent) = model.silent
 MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, value::Real)
-    MOI.set(model, MOI.RawOptimizerAttribute("max_cpu_time"), Float64(value))
+    MOI.set(model, MOI.RawOptimizerAttribute("max_wall_time"), Float64(value))
     return
 end
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, ::Nothing)
-    delete!(model.options, "max_cpu_time")
+    delete!(model.options, "max_wall_time")
     return
 end
 
 function MOI.get(model::Optimizer, ::MOI.TimeLimitSec)
-    return get(model.options, "max_cpu_time", nothing)
+    return get(model.options, "max_wall_time", nothing)
 end
 
 ### MOI.RawOptimizerAttribute


### PR DESCRIPTION
While setting up the fork for updating the docs on linear solvers, I remembered that this was a thing that sometimes bugged me a lot: 
When using different linear solvers, cpu time can massively deviate from wall time. For example, when using pardiso on a cluster computer, I have had instances that exited with a cpu time of 10000s after less than 400s wall time. 
The behavior varies widely between linear solvers, which makes things somewhat inconsistent. 
If this does not violate JuMP/MOI conventions (think the MOI docs are not really explicit on this), it might be more user-friendly to go to wall time for `MOI.TimeLimitSec`? 
Users who need cpu time could still manually set the option (as is currently possible for wall time).  
In case this is a stupid idea for another reason, please just delete :D