### PR TITLE
Add support for MOI.ScalarNonlinearFunction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,11 @@ Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Ipopt_jll = "=300.1400.400, =300.1400.403, =300.1400.1000, =300.1400.1200"
-MathOptInterface = "1"
+MathOptInterface = "1.17"
 OpenBLAS32_jll = "0.3.10"
 PrecompileTools = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1080,6 +1080,15 @@ end
 
 ### MOI.ConstraintPrimal
 
+row(model::Optimizer, ci::MOI.ConstraintIndex{<:_FUNCTIONS}) = ci.value
+
+function row(
+    model::Optimizer,
+    ci::MOI.ConstraintIndex{MOI.ScalarNonlinearFunction},
+)
+    return length(model.qp_data) + ci.value
+end
+
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintPrimal,
@@ -1087,7 +1096,7 @@ function MOI.get(
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
-    return model.inner.g[ci.value]
+    return model.inner.g[row(ci)]
 end
 
 function MOI.get(
@@ -1112,7 +1121,7 @@ function MOI.get(
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
     s = -_dual_multiplier(model)
-    return s * model.inner.mult_g[ci.value]
+    return s * model.inner.mult_g[row(ci)]
 end
 
 function MOI.get(

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -9,6 +9,12 @@ const _PARAMETER_OFFSET = 0x00f0000000000000
 
 _is_parameter(x::MOI.VariableIndex) = x.value >= _PARAMETER_OFFSET
 
+_is_parameter(term::MOI.ScalarAffineTerm) = _is_parameter(term.variable)
+
+function _is_parameter(term::MOI.ScalarQuadraticTerm)
+    return _is_parameter(term.variable_1) || _is_parameter(term.variable_2)
+end
+
 """
     Optimizer()
 
@@ -67,6 +73,7 @@ const _SETS =
 const _FUNCTIONS = Union{
     MOI.ScalarAffineFunction{Float64},
     MOI.ScalarQuadraticFunction{Float64},
+    MOI.ScalarNonlinearFunction,
 }
 
 MOI.get(::Optimizer, ::MOI.SolverVersion) = "3.14.4"
@@ -150,6 +157,39 @@ function MOI.set(
     p = model.parameters[MOI.VariableIndex(ci.value)]
     model.nlp_model[p] = set.value
     return
+end
+
+_replace_parameters(model::Optimizer, f) = f
+
+function _replace_parameters(model::Optimizer, f::MOI.VariableIndex)
+    if _is_parameter(f)
+        return model.parameters[f]
+    end
+    return f
+end
+
+function _replace_parameters(model::Optimizer, f::MOI.ScalarAffineFunction)
+    if any(_is_parameter, f.terms)
+        g = convert(MOI.ScalarNonlinearFunction, f)
+        return _replace_parameters(model, g)
+    end
+    return f
+end
+
+function _replace_parameters(model::Optimizer, f::MOI.ScalarQuadraticFunction)
+    if any(_is_parameter, f.affine_terms) ||
+       any(_is_parameter, f.quadratic_terms)
+        g = convert(MOI.ScalarNonlinearFunction, f)
+        return _replace_parameters(model, g)
+    end
+    return f
+end
+
+function _replace_parameters(model::Optimizer, f::MOI.ScalarNonlinearFunction)
+    for (i, arg) in enumerate(f.args)
+        f.args[i] = _replace_parameters(model, arg)
+    end
+    return f
 end
 
 function MOI.supports_constraint(
@@ -375,6 +415,77 @@ function MOI.set(
     return
 end
 
+### ScalarNonlinearFunction
+
+function MOI.is_valid(
+    model::Optimizer,
+    ci::MOI.ConstraintIndex{MOI.ScalarNonlinearFunction,<:_SETS},
+)
+    if model.nlp_model === nothing
+        return false
+    end
+    index = MOI.Nonlinear.ConstraintIndex(ci.value)
+    return MOI.is_valid(model.nlp_model, index)
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.ScalarNonlinearFunction,
+    s::_SETS,
+)
+    if model.nlp_model === nothing
+        model.nlp_model = MOI.Nonlinear.Model()
+    end
+    if !isempty(model.parameters)
+        _replace_parameters(model, f)
+    end
+    index = MOI.Nonlinear.add_constraint(model.nlp_model, f, s)
+    model.inner = nothing
+    return MOI.ConstraintIndex{typeof(f),typeof(s)}(index.value)
+end
+
+function MOI.set(
+    model::Optimizer,
+    attr::MOI.ObjectiveFunction{MOI.ScalarNonlinearFunction},
+    func::MOI.ScalarNonlinearFunction,
+)
+    if model.nlp_model === nothing
+        model.nlp_model = MOI.Nonlinear.Model()
+    end
+    if !isempty(model.parameters)
+        _replace_parameters(model, func)
+    end
+    MOI.Nonlinear.set_objective(model.nlp_model, func)
+    model.inner = nothing
+    return
+end
+
+### UserDefinedFunction
+
+MOI.supports(model::Optimizer, ::MOI.UserDefinedFunction) = true
+
+function MOI.set(model::Optimizer, attr::MOI.UserDefinedFunction, args)
+    if model.nlp_model === nothing
+        model.nlp_model = MOI.Nonlinear.Model()
+    end
+    MOI.Nonlinear.register_operator(
+        model.nlp_model,
+        attr.name,
+        attr.arity,
+        args...,
+    )
+    return
+end
+
+### ListOfSupportedNonlinearOperators
+
+function MOI.get(model::Optimizer, attr::MOI.ListOfSupportedNonlinearOperators)
+    if model.nlp_model === nothing
+        model.nlp_model = MOI.Nonlinear.Model()
+    end
+    return MOI.get(model.nlp_model, attr)
+end
+
 ### MOI.VariablePrimalStart
 
 function MOI.supports(
@@ -554,6 +665,9 @@ function MOI.set(
     func::F,
 ) where {F<:Union{MOI.VariableIndex,<:_FUNCTIONS}}
     MOI.set(model.qp_data, attr, func)
+    if model.nlp_model !== nothing
+        MOI.Nonlinear.set_objective(model.nlp_model, nothing)
+    end
     model.inner = nothing
     return
 end
@@ -637,6 +751,11 @@ function _setup_model(model::Optimizer)
         # Don't attempt to create a problem because Ipopt will error.
         model.invalid_model = true
         return
+    end
+    if model.nlp_model !== nothing
+        backend = MOI.Nonlinear.SparseReverseMode()
+        evaluator = MOI.Nonlinear.Evaluator(model.nlp_model, backend, vars)
+        model.nlp_data = MOI.NLPBlockData(evaluator)
     end
     has_quadratic_constraints =
         any(isequal(_kFunctionTypeScalarQuadratic), model.qp_data.function_type)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1096,7 +1096,7 @@ function MOI.get(
 )
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
-    return model.inner.g[row(ci)]
+    return model.inner.g[row(model, ci)]
 end
 
 function MOI.get(
@@ -1121,7 +1121,7 @@ function MOI.get(
     MOI.check_result_index_bounds(model, attr)
     MOI.throw_if_not_valid(model, ci)
     s = -_dual_multiplier(model)
-    return s * model.inner.mult_g[row(ci)]
+    return s * model.inner.mult_g[row(model, ci)]
 end
 
 function MOI.get(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,11 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+import Pkg
+if get(ENV, "CI", "false") == "true"
+    Pkg.pkg"add MathOptInterface#od/nlp-expr"
+end
+
 using Test
 
 function runtests(mod)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-import Pkg
-if get(ENV, "CI", "false") == "true"
-    Pkg.pkg"add MathOptInterface#master"
-end
-
 using Test
 
 function runtests(mod)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@
 
 import Pkg
 if get(ENV, "CI", "false") == "true"
-    Pkg.pkg"add MathOptInterface#od/nlp-expr"
+    Pkg.pkg"add MathOptInterface#master"
 end
 
 using Test


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/MathOptInterface.jl/pull/2059

The most-basic example is working:

```julia
julia> import Ipopt

julia> const MOI = Ipopt.MOI
MathOptInterface

julia> model = Ipopt.Optimizer()
Ipopt.Optimizer

julia> x = MOI.add_variable(model)
MathOptInterface.VariableIndex(1)

julia> MOI.add_constraint(
           model,
           MOI.ScalarNonlinearFunction{Float64}(:^, Any[x, 2]), 
           MOI.LessThan(1.0))
MathOptInterface.ConstraintIndex{MathOptInterface.ScalarNonlinearFunction{Float64}, MathOptInterface.LessThan{Float64}}(1)

julia> MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)

julia> f = MOI.ScalarNonlinearFunction{Float64}(:exp, Any[x])
MathOptInterface.ScalarNonlinearFunction{Float64}(:exp, Any[MathOptInterface.VariableIndex(1)])

julia> MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)

julia> MOI.optimize!(model)
This is Ipopt version 3.14.4, running with linear solver MUMPS 5.4.1.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        1
Number of nonzeros in Lagrangian Hessian.............:        2

Total number of variables............................:        1
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        0
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        1
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        1

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0000000e+00 0.00e+00 1.00e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  7.1653131e-01 0.00e+00 7.03e-01  -1.7 3.33e-01    -  1.00e+00 1.00e+00f  1
   2  2.8647417e-01 5.63e-01 2.00e-01  -1.7 9.17e-01    -  1.00e+00 1.00e+00f  1
   3  3.0881253e-01 3.81e-01 9.91e-02  -1.7 4.99e-01    -  1.00e+00 5.50e-01h  1
   4  3.8678069e-01 0.00e+00 4.85e-02  -1.7 2.25e-01    -  1.00e+00 1.00e+00f  1
   5  3.6927833e-01 0.00e+00 2.77e-04  -2.5 1.39e-01    -  1.00e+00 1.00e+00h  1
   6  3.6803998e-01 0.00e+00 1.14e-05  -3.8 8.84e-03    -  1.00e+00 1.00e+00h  1
   7  3.6788138e-01 0.00e+00 1.66e-07  -5.7 8.73e-04    -  1.00e+00 1.00e+00h  1
   8  3.6787944e-01 0.00e+00 2.47e-11  -8.6 1.07e-05    -  1.00e+00 1.00e+00h  1

Number of Iterations....: 8

                                   (scaled)                 (unscaled)
Objective...............:   3.6787944185279176e-01    3.6787944185279176e-01
Dual infeasibility......:   2.4747093263499664e-11    2.4747093263499664e-11
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   0.0000000000000000e+00    0.0000000000000000e+00
Complementarity.........:   2.5258713785469758e-09    2.5258713785469758e-09
Overall NLP error.......:   2.5258713785469758e-09    2.5258713785469758e-09


Number of objective function evaluations             = 9
Number of objective gradient evaluations             = 9
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 9
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 9
Number of Lagrangian Hessian evaluations             = 8
Total seconds in IPOPT                               = 0.005

EXIT: Optimal Solution Found.

julia> @test isapprox(MOI.get(model, MOI.VariablePrimal(), x), -1; atol = 1e-6)
Test Passed

julia> @test isapprox(MOI.get(model, MOI.ObjectiveValue()), exp(-1); atol = 1e-6)
Test Passed
```