### PR TITLE
Update version of actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
We're well behind https://github.com/actions/cache/releases/tag/v3.0.11

Current runs are giving warnings

![image](https://user-images.githubusercontent.com/8177701/207200498-a19dbdac-0694-4213-a43d-bfd69145ffe5.png)
