### PR TITLE
Add GetIpoptCurrentIterate and GetIpoptCurrentViolations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ See the [Ipopt documentation](https://coin-or.github.io/Ipopt/OUTPUT.html) for
 an explanation of the arguments to the callback. They are identical to the
 output contained in the logging table printed to the screen.
 
+To access the current solution and primal, dual, and complementarity violations
+of each iteration, use `Ipopt.GetIpoptCurrentViolations` and
+`Ipopt.GetIpoptCurrentIterate`. The two functions are identical to the ones in
+the [Ipopt C interface](https://coin-or.github.io/Ipopt/INTERFACES.html).
+
 ## C Interface Wrapper
 
 Ipopt.jl wraps the [Ipopt C interface](https://coin-or.github.io/Ipopt/INTERFACES.html) with minimal modifications.

--- a/src/C_wrapper.jl
+++ b/src/C_wrapper.jl
@@ -465,3 +465,91 @@ function IpoptSolve(prob::IpoptProblem)
     prob.status = ret
     return prob.status
 end
+
+function GetIpoptCurrentIterate(
+    prob::IpoptProblem,
+    scaled::Bool,
+    n::Integer,
+    x::Union{Ptr{Cvoid},Vector{Float64}},
+    z_L::Union{Ptr{Cvoid},Vector{Float64}},
+    z_U::Union{Ptr{Cvoid},Vector{Float64}},
+    m::Integer,
+    g::Union{Ptr{Cvoid},Vector{Float64}},
+    lambda::Union{Ptr{Cvoid},Vector{Float64}},
+)
+    ret = ccall(
+        (:GetIpoptCurrentIterate, libipopt),
+        Cint,
+        (
+            Ptr{Cvoid},
+            Cint,
+            Cint,
+            Ptr{Float64},
+            Ptr{Float64},
+            Ptr{Float64},
+            Cint,
+            Ptr{Float64},
+            Ptr{Float64},
+        ),
+        prob.ipopt_problem,
+        scaled,
+        n,
+        x,
+        z_L,
+        z_U,
+        m,
+        g,
+        lambda,
+    )
+    if ret == 0
+        error("IPOPT: Something went wrong getting the current iterate.")
+    end
+    return
+end
+
+function GetIpoptCurrentViolations(
+    prob::IpoptProblem,
+    scaled::Bool,
+    n::Integer,
+    x_L_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    x_U_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_x_L::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_x_U::Union{Ptr{Cvoid},Vector{Float64}},
+    grad_lag_x::Union{Ptr{Cvoid},Vector{Float64}},
+    m::Integer,
+    nlp_constraint_violation::Union{Ptr{Cvoid},Vector{Float64}},
+    compl_g::Union{Ptr{Cvoid},Vector{Float64}},
+)
+    ret = ccall(
+        (:GetIpoptCurrentViolations, libipopt),
+        Cint,
+        (
+            Ptr{Cvoid},
+            Cint,
+            Cint,
+            Ptr{Float64},
+            Ptr{Float64},
+            Ptr{Float64},
+            Ptr{Float64},
+            Ptr{Float64},
+            Cint,
+            Ptr{Float64},
+            Ptr{Float64},
+        ),
+        prob.ipopt_problem,
+        scaled,
+        n,
+        x_L_violation,
+        x_U_violation,
+        compl_x_L,
+        compl_x_U,
+        grad_lag_x,
+        m,
+        nlp_constraint_violation,
+        compl_g,
+    )
+    if ret == 0
+        error("IPOPT: Something went wrong getting the current violations.")
+    end
+    return
+end

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -174,6 +174,30 @@ function test_hs071()
         alpha_pr::Float64,
         ls_trials::Cint,
     )
+        m, n = 2, 4
+        x, z_L, z_U = zeros(n), zeros(n), zeros(n)
+        g, lambda = zeros(m), zeros(m)
+        scaled = false
+        Ipopt.GetIpoptCurrentIterate(prob, scaled, n, x, z_L, z_U, m, g, lambda)
+        x_L_violation, x_U_violation = zeros(n), zeros(n)
+        compl_x_L, compl_x_U, grad_lag_x = zeros(n), zeros(n), zeros(n)
+        nlp_constraint_violation, compl_g = zeros(m), zeros(m)
+        Ipopt.GetIpoptCurrentViolations(
+            prob,
+            scaled,
+            n,
+            x_L_violation,
+            x_U_violation,
+            compl_x_L,
+            compl_x_U,
+            grad_lag_x,
+            m,
+            nlp_constraint_violation,
+            compl_g,
+        )
+        @test x .+ x_L_violation >= x_L
+        @test x .- x_U_violation <= x_U
+        @test g_L <= g .- nlp_constraint_violation <= g_U
         return iter_count < 1  # Interrupts after one iteration.
     end
 


### PR DESCRIPTION
Closes #349 

I haven't documented the usage in the README. I think these functions are reasonably advanced, so people using them should be comfortable looking at the C API for details? 