### PR TITLE
Use the last version of Ipopt_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ OpenBLAS32_jll = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
-Ipopt_jll = "=300.1400.400, =300.1400.1300"
+Ipopt_jll = "=300.1400.400, =300.1400.1301"
 MathOptInterface = "1.17"
 OpenBLAS32_jll = "0.3.10"
 PrecompileTools = "1"


### PR DESCRIPTION
Ipopt was recompiled with the last release of `MUMPS` and `SPRAL`.