### PR TITLE
Some performance and allocation optimizations

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -240,22 +240,17 @@ function eval_sparse_gradient(
     return i
 end
 
-function append_sparse_hessian_structure!(
-    f::MOI.ScalarQuadraticFunction,
-    indices,
-)
+function append_sparse_hessian_structure!(f::MOI.ScalarQuadraticFunction, H)
     for term in f.quadratic_terms
         if _is_parameter(term.variable_1) || _is_parameter(term.variable_2)
             continue
         end
-        push!(indices, (term.variable_1.value, term.variable_2.value))
+        push!(H, (term.variable_1.value, term.variable_2.value))
     end
-    return indices
+    return
 end
 
-function append_sparse_hessian_structure!(f::MOI.ScalarAffineFunction, indices)
-    return indices
-end
+append_sparse_hessian_structure!(::MOI.ScalarAffineFunction, H) = nothing
 
 function eval_sparse_hessian(
     ∇²f::AbstractVector{T},
@@ -510,7 +505,8 @@ function MOI.eval_constraint_jacobian(
 end
 
 function MOI.hessian_lagrangian_structure(block::QPBlockData)
-    H = append_sparse_hessian_structure!(block.objective, Tuple{Int,Int}[])
+    H = Tuple{Int,Int}[]
+    append_sparse_hessian_structure!(block.objective, H)
     for constraint in block.constraints
         append_sparse_hessian_structure!(constraint, H)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -182,13 +182,11 @@ end
 
 function sparse_hessian_structure(f::MOI.ScalarQuadraticFunction{T}) where {T}
     indices = Tuple{Int,Int}[]
-    i = 1
     for term in f.quadratic_terms
         if _is_parameter(term.variable_1) || _is_parameter(term.variable_2)
             continue
         end
         push!(indices, (term.variable_1.value, term.variable_2.value))
-        i += 1
     end
     return indices
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -403,8 +403,8 @@ function MOI.eval_constraint(
     g::AbstractVector{T},
     x::AbstractVector{T},
 ) where {T}
-    for i in 1:length(block.constraints)
-        g[i] = eval_function(block.constraints[i], x, block.parameters)
+    for (i, constraint) in enumerate(block.constraints)
+        g[i] = eval_function(constraint, x, block.parameters)
     end
     return
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -163,10 +163,10 @@ function eval_dense_gradient(
 end
 
 function append_sparse_gradient_structure!(
-    f::MOI.ScalarQuadraticFunction{T},
+    f::MOI.ScalarQuadraticFunction,
     J,
     row,
-) where {T}
+)
     for term in f.affine_terms
         if !_is_parameter(term.variable)
             push!(J, (row, term.variable.value))
@@ -183,11 +183,7 @@ function append_sparse_gradient_structure!(
     return
 end
 
-function append_sparse_gradient_structure!(
-    f::MOI.ScalarAffineFunction{T},
-    J,
-    row,
-) where {T}
+function append_sparse_gradient_structure!(f::MOI.ScalarAffineFunction, J, row)
     for term in f.terms
         if !_is_parameter(term.variable)
             push!(J, (row, term.variable.value))
@@ -282,10 +278,7 @@ function MOI.set(
     block::QPBlockData{T},
     ::MOI.ObjectiveFunction{F},
     f::F,
-) where {
-    T,
-    F<:Union{MOI.VariableIndex,MOI.ScalarAffineFunction{T}},
-}
+) where {T,F<:Union{MOI.VariableIndex,MOI.ScalarAffineFunction{T}}}
     block.objective = convert(MOI.ScalarAffineFunction{T}, f)
     block.objective_function_type = _function_info(f)
     return


### PR DESCRIPTION
https://github.com/jump-dev/Ipopt.jl/pull/357 appears to increase the memory allocation for a problem I have by ~4x in number and ~1.7x in size. (It doesn't affect the constructed problem but it was affecting the overall performance on a somewhat memory constraint system (relative to the problem size))

Most of the allocations seems to be caused by unnecessary allocation of the array which is fixed in the second commit. The first and the third commits are some minor and easy optimizations I noticed while going through the code. These changes got the final allocation to be ~2x in number and ~1.1x in size.

The remaining additional allocation comes from the use of quadratic function to uniformly store all the constraints and objective information. (The extra allocation has two parts, one from the creation of the empty quadratic term vector when converting to a quadratic function and the other one from the index mapping for those terms at https://github.com/jump-dev/MathOptInterface.jl/blob/36ed9d8c8561d2fdc0cb7c1fe773566cbc0c7e29/src/Utilities/functions.jl#L315 ). This is fixed in the last commit by making the functions unions and rely on the union splitting from the compiler to deal with the resulting type instability. With this last commit, I got an allocation count/size that's basically the same as before.
