### PR TITLE
Add support for get MOI.NLPBlock

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -624,6 +624,10 @@ MOI.get(model::Optimizer, ::MOI.NLPBlockDualStart) = model.nlp_dual_start
 
 MOI.supports(::Optimizer, ::MOI.NLPBlock) = true
 
+# This may also be set by `optimize!` and contain the block created from
+# ScalarNonlinearFunction
+MOI.get(model::Optimizer, ::MOI.NLPBlock) = model.nlp_data
+
 function MOI.set(model::Optimizer, ::MOI.NLPBlock, nlp_data::MOI.NLPBlockData)
     model.nlp_data = nlp_data
     model.inner = nothing

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -168,6 +168,7 @@ function test_check_derivatives_for_naninf()
     # MOI.set(model, MOI.RawOptimizerAttribute("check_derivatives_for_naninf"), "no")
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INVALID_MODEL
+    @test MOI.get(model, MOI.NLPBlock()) isa MOI.NLPBlockData
     return
 end
 
@@ -356,6 +357,18 @@ function test_scalar_nonlinear_function_is_valid()
     c = MOI.add_constraint(model, f, MOI.EqualTo(0.0))
     @test c isa MOI.ConstraintIndex{F,S}
     @test MOI.is_valid(model, c) == true
+    return
+end
+
+function test_scalar_nonlinear_function_nlp_block()
+    model = Ipopt.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:^, Any[x, 4])
+    MOI.add_constraint(model, f, MOI.LessThan(1.0))
+    MOI.optimize!(model)
+    block = MOI.get(model, MOI.NLPBlock())
+    @test !block.has_objective
+    @test block.evaluator isa MOI.Nonlinear.Evaluator
     return
 end
 


### PR DESCRIPTION
@ccoffrin you can replace
https://github.com/lanl-ansi/rosetta-opf/blob/1867107cb8b2d036dcd7ddac13637f627dd84ab5/jump.jl#L119C5-L119C55
with
```
nlp_block = unsafe_backend(model).nlp_data
```
but once this is merged you'll be able to use
```
nlp_block = JuMP.MOI.get(unsafe_backend(model), JuMP.MOI.NLPBlock())
```