### PR TITLE
Release 1.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ipopt"
 uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 repo = "https://github.com/jump-dev/Ipopt.jl.git"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
@@ -12,7 +12,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 HSL_jll = "2, 2023"
-Ipopt_jll = "=300.1400.400, =300.1400.1303"
+Ipopt_jll = "=300.1400.400, =300.1400.1400"
 LinearAlgebra = "<0.0.1, 1.6"
 MathOptInterface = "1.25"
 OpenBLAS32_jll = "0.3.10"


### PR DESCRIPTION
close #403 
Ipopt v3.14.13 -> v3.14.14
Bump the version of SPRAL
Fix the problem with OpenMP for MUMPS 5.6.2