### PR TITLE
Fix bugs related to ScalarNonlinearFunction

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -450,7 +450,7 @@ end
 function MOI.supports(
     ::Optimizer,
     ::MOI.ConstraintDualStart,
-    ::Type{MOI.ConstraintIndex{F,<:_SETS}},
+    ::Type{<:MOI.ConstraintIndex{F,<:_SETS}},
 ) where {
     F<:Union{
         MOI.ScalarAffineFunction{Float64},
@@ -560,6 +560,14 @@ function MOI.set(
     model.nlp_model.constraints[index] = MOI.Nonlinear.Constraint(func, set)
     model.inner = nothing
     return
+end
+
+function MOI.supports(
+    ::Optimizer,
+    ::MOI.ConstraintDualStart,
+    ::Type{<:MOI.ConstraintIndex{MOI.ScalarNonlinearFunction,<:_SETS}},
+)
+    return true
 end
 
 function MOI.get(

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -463,7 +463,7 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.ConstraintDualStart,
-    c::MOI.ConstraintIndex{F,_SETS},
+    c::MOI.ConstraintIndex{F,<:_SETS},
 ) where {
     F<:Union{
         MOI.ScalarAffineFunction{Float64},

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -87,6 +87,10 @@ function test_ConstraintDualStart()
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
         MOI.LessThan(1.5),
     )
+    @test MOI.supports(model, MOI.ConstraintDualStart(), typeof(l))
+    @test MOI.supports(model, MOI.ConstraintDualStart(), typeof(u))
+    @test MOI.supports(model, MOI.ConstraintDualStart(), typeof(e))
+    @test MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
     @test MOI.get(model, MOI.ConstraintDualStart(), l) === nothing
     @test MOI.get(model, MOI.ConstraintDualStart(), u) === nothing
     @test MOI.get(model, MOI.ConstraintDualStart(), e) === nothing
@@ -125,6 +129,7 @@ function test_ConstraintDualStart_ScalarNonlinearFunction()
     g = 1.0 * x[1] + 1.0 * x[2]
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{typeof(g)}(), g)
+    @test MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
     @test MOI.get(model, MOI.ConstraintDualStart(), c) === nothing
     MOI.set(model, MOI.ConstraintDualStart(), c, 1.15)
     MOI.optimize!(model)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -606,6 +606,28 @@ function test_mixing_new_old_api()
     return
 end
 
+function test_nlp_model_objective_function_type()
+    model = Ipopt.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:sqrt, Any[x])
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    F = MOI.get(model, MOI.ObjectiveFunctionType())
+    @test F == MOI.ScalarNonlinearFunction
+    return
+end
+
+function test_nlp_model_set_set()
+    model = Ipopt.Optimizer()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:sqrt, Any[x])
+    c = MOI.add_constraint(model, f, MOI.LessThan(2.0))
+    @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(2.0)
+    MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(3.0))
+    @test MOI.get(model, MOI.ConstraintSet(), c) == MOI.LessThan(3.0)
+    return
+end
+
 end  # module TestMOIWrapper
 
 TestMOIWrapper.runtests()


### PR DESCRIPTION
Closes #428

This PR gets rid of `_FUNCTIONS` because it was obscuring a number of bugs, and I've also fixed the return of `ObjectiveFunctionType` if the function was nonlinear.

I think we mostly haven't run into this in the past because we're using caching in most places.