### PR TITLE
Prep for v1.10.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Ipopt"
 uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 repo = "https://github.com/jump-dev/Ipopt.jl.git"
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"


### PR DESCRIPTION
This release will contain only #478. I don't plan to make a release announcement, because I want to see if anybody notices. 

If there any problems, we can revert #478 and tag v1.10.1.

If you, future reader, have stumbled upon this PR because you're trying to understand what changed in the v1.10 release because something broke, please leave a comment below.