### PR TITLE
Change function type from affine to quadratic

### DIFF
--- a/ext/IpoptMathOptInterfaceExt/utils.jl
+++ b/ext/IpoptMathOptInterfaceExt/utils.jl
@@ -75,7 +75,7 @@ mutable struct QPBlockData{T}
     function QPBlockData{T}() where {T}
         return new(
             zero(MOI.ScalarQuadraticFunction{T}),
-            _kFunctionTypeScalarAffine,
+            _kFunctionTypeScalarQuadratic,
             Union{MOI.ScalarAffineFunction{T},MOI.ScalarQuadraticFunction{T}}[],
             T[],
             T[],


### PR DESCRIPTION
`objective_function_type` will be consistent with the default `objective`.