### PR TITLE
Provide the user_data to the callbacks

### DIFF
--- a/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl
+++ b/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl
@@ -1285,6 +1285,7 @@ function _setup_model(model::Optimizer)
         eval_grad_f_cb,
         eval_jac_g_cb,
         has_hessian ? eval_h_cb : nothing,
+        nothing,  # we could use the model in the future but it is a breaking change for the signature of the callback
     )
     if model.sense == MOI.MIN_SENSE
         Ipopt.AddIpoptNumOption(model.inner, "obj_scaling_factor", 1.0)


### PR DESCRIPTION
@odow 
When I created the C / Julia interface for `Uno`, I checked a few times the interfaces of other nonlinear solvers (`Ipopt`, `KNITRO`, `GALAHAD`) and I noticed that in `Ipopt.jl` we never provide a way to pass `user_data`.
This means that `model::Optimizer` is passed as a closure, and the same applies to `model::AbstractNLPModel` in `NLPModelsIpopt.jl`.

In `UnoSolver.jl`, I added an option to pass `user_data` / `user_model` when creating the internal solver model (`Ipopt.IpoptProblem` in this repository).
If `user_data` is `nothing`, we keep the current signature; otherwise, we pass `user_data` / `user_model` as the first argument to all Julia callbacks.
This is what we expect in the signatures of the NLP API in `MathOptInterface.jl` or `NLPModels.jl`.

I also think it is a clean way to pass a list of parameters to an objective or constraints.
For example, if we have a complex physical problem, we would like to store them in a Julia structure and pass this structure as an argument to the Julia functions.
I find it neater than using closures.

The current PR is non-breaking because, by default, `user_data` / `user_model` is `nothing`.
I would like to have your point of view (as well as that of other users) before I add unit tests for coverage.

`Ipopt.jl`: https://github.com/jump-dev/Ipopt.jl/blob/master/ext/IpoptMathOptInterfaceExt/MOI_wrapper.jl#L1242-L1264
`UnoSolver.jl`: https://github.com/cvanaret/Uno/blob/main/interfaces/Julia/ext/UnoSolverMathOptInterfaceExt/MOI_wrapper.jl#L1294-L1301