### PR TITLE
Drop Julia v1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [default]
         include:
-          # Test Julia v1.9
-          - version: '1.9'
-            os: ubuntu-latest
-            arch: x64
           # Test again linux ARM
           - version: '1'
             os: ubuntu-24.04-arm

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ MathOptInterface = "1.48"
 OpenBLAS32_jll = "0.3.10"
 PrecompileTools = "1"
 Test = "1"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 HSL_jll = "017b0a0e-03f4-516a-9b91-836bbd1904dd"


### PR DESCRIPTION
We dropped support for Julia v1.9 in MOI. There is also
https://github.com/jump-dev/Ipopt.jl/blob/b5b0e62b11aff4ae4bf0c5f0bc852c55b8953b4f/README.md?plain=1#L334
and
https://github.com/jump-dev/Ipopt.jl/blob/b5b0e62b11aff4ae4bf0c5f0bc852c55b8953b4f/README.md?plain=1#L349
that we could clean up but they could also stay because earlier Julia will make you install older version if Ipopt so it's kind of still true